### PR TITLE
fix: hide Not Linked and Finished drops by default in inventory

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -36,7 +36,7 @@ default_settings = {
         "show_benefit_other": True,
         "show_expired": False,
         "show_finished": False,
-        "show_not_linked": True,
+        "show_not_linked": False,
         "show_upcoming": True,
     },
     "minimum_refresh_interval_minutes": 30,

--- a/web/index.html
+++ b/web/index.html
@@ -122,7 +122,7 @@
                             <span>Active</span>
                         </label>
                         <label class="filter-checkbox">
-                            <input type="checkbox" id="filter-not-linked" checked />
+                            <input type="checkbox" id="filter-not-linked" />
                             <span>Not Linked</span>
                         </label>
                         <label class="filter-checkbox">

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -597,38 +597,24 @@ function campaignMatchesFilters(campaign, filters) {
     // Calculate "finished" status: all drops claimed
     const isFinished = campaign.total_drops > 0 && campaign.claimed_drops === campaign.total_drops;
 
-    // Always hide finished campaigns unless explicitly shown (fix #52)
+    const hasGameFilter = filters.game_name_search && filters.game_name_search.length > 0;
+
+    // Exclusion filters: always hide these unless the checkbox is ON (closes #52)
     if (!filters.show_finished && isFinished) return false;
 
-    // Always hide not-linked campaigns unless explicitly shown (fix #51)
-    if (!filters.show_not_linked && !campaign.linked) return false;
+    // Linked/Not Linked: AND filters applied on top of status (closes #51)
+    if (filters.show_linked && !campaign.linked) return false;
+    if (filters.show_not_linked && campaign.linked) return false;
 
-    // Check if any filter is enabled
-    const hasGameFilter = filters.game_name_search && filters.game_name_search.length > 0;
-    const anyFilterEnabled = filters.show_active || filters.show_not_linked ||
-        filters.show_upcoming || filters.show_expired ||
-        filters.show_finished || hasGameFilter;
+    // Status filters: OR logic — if any checked, show only matching campaigns
+    const hasStatusFilters = filters.show_active || filters.show_upcoming || filters.show_expired;
 
-    // If no filters enabled, show all remaining campaigns
-    if (!anyFilterEnabled) {
-        return true;
-    }
-
-    // Check status filters (OR logic - campaign matches if ANY checked filter applies)
-    let statusMatch = false;
-
-    if (filters.show_active && campaign.active) statusMatch = true;
-    if (filters.show_not_linked && !campaign.linked) statusMatch = true;
-    if (filters.show_upcoming && campaign.upcoming) statusMatch = true;
-    if (filters.show_expired && campaign.expired) statusMatch = true;
-    if (filters.show_finished && isFinished) statusMatch = true;
-
-    // If status filters are enabled but campaign doesn't match any, filter it out
-    const hasStatusFilters = filters.show_active || filters.show_not_linked ||
-        filters.show_upcoming || filters.show_expired ||
-        filters.show_finished;
-    if (hasStatusFilters && !statusMatch) {
-        return false;
+    if (hasStatusFilters) {
+        let statusMatch = false;
+        if (filters.show_active && campaign.active) statusMatch = true;
+        if (filters.show_upcoming && campaign.upcoming) statusMatch = true;
+        if (filters.show_expired && campaign.expired) statusMatch = true;
+        if (!statusMatch) return false;
     }
 
     // Check game name filter (AND logic with status filters, OR logic among selected games)

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -597,13 +597,19 @@ function campaignMatchesFilters(campaign, filters) {
     // Calculate "finished" status: all drops claimed
     const isFinished = campaign.total_drops > 0 && campaign.claimed_drops === campaign.total_drops;
 
+    // Always hide finished campaigns unless explicitly shown (fix #52)
+    if (!filters.show_finished && isFinished) return false;
+
+    // Always hide not-linked campaigns unless explicitly shown (fix #51)
+    if (!filters.show_not_linked && !campaign.linked) return false;
+
     // Check if any filter is enabled
     const hasGameFilter = filters.game_name_search && filters.game_name_search.length > 0;
     const anyFilterEnabled = filters.show_active || filters.show_not_linked ||
         filters.show_upcoming || filters.show_expired ||
         filters.show_finished || hasGameFilter;
 
-    // If no filters enabled, show all campaigns
+    // If no filters enabled, show all remaining campaigns
     if (!anyFilterEnabled) {
         return true;
     }


### PR DESCRIPTION
## Summary

Fixes inventory filter issues #51 and #52 with an improved filter design:

- **Finished drops hidden by default** — campaigns where all drops are claimed are hidden unless the *Finished* checkbox is explicitly checked (closes #52)
- **Not Linked as AND filter** — checking *Not Linked* + *Active* shows only campaigns that are **both** active and not linked, instead of ORing them together (closes #51)
- Linked works the same way (AND filter)
- Active / Upcoming / Expired remain OR-based status filters

## Changes

- `web/static/app.js`: Finished is now an exclusion filter (hide by default). Linked/Not Linked are AND filters applied on top of the status OR group.
- `web/index.html`: Removed `checked` default from `filter-not-linked`
- `src/config/settings.py`: `show_not_linked` and `show_finished` default to `False`

## Filter behavior after this PR

| What you want | Checkboxes |
|---|---|
| See all active campaigns | Active ✓ |
| See active campaigns I haven't linked | Active ✓ + Not Linked ✓ |
| See what I've already claimed | Finished ✓ |
| Default view (no checkboxes) | Shows all non-finished, link-status-neutral campaigns |