### PR TITLE
fix: handle None sendSpadeEvents response — prevents critical crash on stream end

### DIFF
--- a/src/models/channel.py
+++ b/src/models/channel.py
@@ -521,6 +521,7 @@ class Channel:
             return False
         try:
             watch_response: JsonType = await self._twitch.gql_request(self._stream._gql_payload)
-            return watch_response["data"]["sendSpadeEvents"]["statusCode"] == 204
-        except RequestException:
+            send_events = (watch_response.get("data") or {}).get("sendSpadeEvents")
+            return send_events is not None and send_events.get("statusCode") == 204
+        except (RequestException, TypeError, AttributeError):
             return False


### PR DESCRIPTION
## Problem

When a stream ends or is temporarily unavailable, Twitch's GQL API returns `null` for `sendSpadeEvents`. The current code tries to subscript `None`:

```python
return watch_response["data"]["sendSpadeEvents"]["statusCode"] == 204
# TypeError: 'NoneType' object is not subscriptable
```

Since `watch_loop` is a **critical task**, this unhandled `TypeError` triggers a full application shutdown — the app exits with `exit_status=0`, and process managers like PM2 don't auto-restart it (they only restart on error exits).

## Fix

```python
send_events = (watch_response.get("data") or {}).get("sendSpadeEvents")
return send_events is not None and send_events.get("statusCode") == 204
```

Returns `False` gracefully when `sendSpadeEvents` is `None` instead of crashing.

## Impact

Without this fix, any stream ending while being watched can silently take down the entire miner until manually restarted.