### PR TITLE
fix: catch GQL exceptions per-game instead of crashing the miner

### DIFF
--- a/src/core/client.py
+++ b/src/core/client.py
@@ -356,7 +356,10 @@ class Twitch:
                 for game in no_acl:
                     # for every campaign without an ACL, for it's game,
                     # add a list of live channels with drops enabled
-                    new_channels.update(await self.get_live_streams(game, drops_enabled=True))
+                    try:
+                        new_channels.update(await self.get_live_streams(game, drops_enabled=True))
+                    except Exception as exc:
+                        logger.warning(f"Failed to fetch channels for {game.name}: {exc} — skipping")
                 # sort them descending by viewers, by priority and by game priority
                 # NOTE: Viewers sort also ensures ONLINE channels are sorted to the top
                 # NOTE: We can drop using the set now, because there's no more channels being added


### PR DESCRIPTION
## Problem

When fetching live channels for a game fails (e.g. Path of Exile triggering `PersistedQueryNotFound` from the `GameDirectory` GQL operation), the exception propagates all the way to `__main__.py` and kills the entire miner process.

## Fix

Wrap the per-game `get_live_streams` call in a `try/except` so a single game failing to fetch channels doesn't crash the whole miner. The game is skipped with a warning log so users can identify which game caused the issue.

```python
try:
    new_channels.update(await self.get_live_streams(game, drops_enabled=True))
except Exception as exc:
    logger.warning(f"Failed to fetch channels for {game.name}: {exc} — skipping")
```

Fixes #38