### PR TITLE
fix: exclude sub drops and expired drops from Wanted Drop Queue

### DIFF
--- a/src/services/stream_selector.py
+++ b/src/services/stream_selector.py
@@ -36,7 +36,9 @@ class StreamSelector:
 
                 wanted_drops = []
                 for drop in campaign.drops:
-                    if drop.is_claimed:
+                    if drop.is_claimed or drop.required_minutes <= 0:
+                        continue
+                    if not drop._base_can_earn():
                         continue
 
                     filtered_benefits = drop.get_wanted_unclaimed_benefits(mining_benefits)


### PR DESCRIPTION
## Problem

Two bugs cause items that can never be earned to appear in the **Wanted Drop Queue**:

1. **Sub drops (0-minute required_minutes)** — only `is_claimed` was checked. Drops with `required_minutes <= 0` are impossible to earn but still appear in the queue.

2. **Expired individual drops** — a campaign can be active (`can_earn_within` passes) while some of its drops have already passed their individual `ends_at`. These expired drops still show up in the queue.

## Fix

In `stream_selector._get_wanted_game_tree`, add two additional checks in the inner drop loop:

```python
if drop.is_claimed or drop.required_minutes <= 0:
    continue
if not drop._base_can_earn():
    continue
```

`_base_can_earn()` already checks `starts_at <= now < ends_at` and `preconditions_met`, making it the correct gate for "can this drop actually be progressed right now".

Fixes #25, #26