### PR TITLE
feat: drop name blacklist to skip regional/exclusive drops

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -47,6 +47,7 @@ default_settings = {
         "UNKNOWN": True,
     },
     "proxy": "",
+    "drop_name_blacklist": [],
 }
 
 
@@ -60,6 +61,7 @@ class Settings:
     minimum_refresh_interval_minutes: int
     mining_benefits: dict[str, bool]
     proxy: str
+    drop_name_blacklist: list[str]
 
     def __init__(self):
         self.load()

--- a/src/services/stream_selector.py
+++ b/src/services/stream_selector.py
@@ -16,6 +16,7 @@ class StreamSelector:
         wanted_games = []
         games_to_watch = settings.games_to_watch
         mining_benefits = settings.mining_benefits
+        blacklist = [kw.lower() for kw in getattr(settings, "drop_name_blacklist", []) if kw.strip()]
         next_hour = datetime.now(timezone.utc) + timedelta(hours=1)
 
         for game_name in games_to_watch:
@@ -37,6 +38,8 @@ class StreamSelector:
                 wanted_drops = []
                 for drop in campaign.drops:
                     if drop.is_claimed:
+                        continue
+                    if blacklist and any(kw in drop.name.lower() for kw in blacklist):
                         continue
 
                     filtered_benefits = drop.get_wanted_unclaimed_benefits(mining_benefits)


### PR DESCRIPTION
## Problem

Some games (e.g. Black Desert) run region-exclusive drop campaigns (JP-only, Korea-only) that the miner detects as earnable but can never actually complete. The miner gets stuck watching these streams indefinitely instead of moving to other campaigns.

## Solution

Add a `drop_name_blacklist` setting (list of strings, case-insensitive). Any drop whose name contains a blacklisted keyword is skipped in the Wanted Queue and not mined.

**`settings.json`:**
```json
{
  "drop_name_blacklist": ["JP", "(KR)", "Japan", "Korea"]
}
```

**How it works:**
- New field `drop_name_blacklist: list[str]` in `Settings` (defaults to `[]`)
- `stream_selector._get_wanted_game_tree` skips blacklisted drops — both for the Wanted Queue display and for the game selection that drives mining
- Case-insensitive substring match
- Empty list = no filtering (backward compatible)

This implements the proof-of-concept from the issue in a configurable way without hardcoding keywords.

Fixes #46