### PR TITLE
fix: restore drops progress by sending watch events via Spade POST

### DIFF
--- a/src/models/channel.py
+++ b/src/models/channel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import gzip
 import json
 import logging
 import re
@@ -12,7 +11,7 @@ from typing import TYPE_CHECKING, Any, SupportsInt, cast
 import aiohttp
 from yarl import URL
 
-from src.config.constants import CALL, ONLINE_DELAY, GQLOperation, GQLQuery, JsonType, URLType
+from src.config.constants import CALL, ONLINE_DELAY, GQLOperation, JsonType, URLType
 from src.config.operations import GQL_OPERATIONS
 from src.exceptions import MinerException, RequestException
 from src.models.game import Game
@@ -54,47 +53,22 @@ class Stream:
                     "broadcast_id": str(self.broadcast_id),
                     "channel_id": str(self.channel.id),
                     "channel": self.channel._login,
-                    "hidden": False,
-                    "live": True,
-                    "location": "channel",
-                    "logged_in": True,
-                    "muted": False,
-                    "player": "site",
-                    "user_id": self.channel._twitch._auth_state.user_id,
-                },
-            }
-        ]
-        return {"data": (b64encode(json_minify(payload).encode("utf8"))).decode("utf8")}
-
-    @property
-    def _gql_payload(self) -> GQLQuery:
-        payload = [
-            {
-                "event": "minute-watched",
-                "properties": {
-                    "broadcast_id": str(self.broadcast_id),
-                    "channel_id": str(self.channel.id),
-                    "channel": self.channel._login,
                     "client_time": isonow(),
                     "game": self.game.name if self.game is not None else "",
                     "game_id": str(self.game.id) if self.game is not None else "",
                     "hidden": False,
                     "is_live": True,
                     "live": True,
+                    "location": "channel",
                     "logged_in": True,
                     "minutes_logged": 1,
                     "muted": False,
-                    "user_id": self.channel._twitch._auth_state.user_id,
+                    "player": "site",
+                    "user_id": int(self.channel._twitch._auth_state.user_id),
                 },
             }
         ]
-        return GQLQuery(
-            (
-                "\n mutation SendEvents($input: SendSpadeEventsInput!) "
-                "{\n sendSpadeEvents(input: $input) {\n statusCode\n}\n}\n"
-            ),
-            b64encode(gzip.compress(json_minify(payload).encode("utf8"))).decode("utf8"),
-        )
+        return {"data": (b64encode(json_minify(payload).encode("utf8"))).decode("utf8")}
 
     @classmethod
     def from_get_stream(cls, channel: Channel, channel_data: JsonType) -> Stream:
@@ -502,8 +476,7 @@ class Channel:
         async with self._twitch.request("HEAD", stream_chunk_url) as head_response:
             return head_response.status == 200
 
-    # NOTE: This is currently unused.
-    async def _send_watch_spade(self) -> bool:
+    async def send_watch(self) -> bool:
         if self._stream is None:
             return False
         if self._spade_url is None:
@@ -513,14 +486,5 @@ class Channel:
                 "POST", self._spade_url, data=self._stream._spade_payload
             ) as response:
                 return response.status == 204
-        except RequestException:
-            return False
-
-    async def send_watch(self) -> bool:
-        if self._stream is None:
-            return False
-        try:
-            watch_response: JsonType = await self._twitch.gql_request(self._stream._gql_payload)
-            return watch_response["data"]["sendSpadeEvents"]["statusCode"] == 204
         except RequestException:
             return False

--- a/tests/test_gql_watch_events.py
+++ b/tests/test_gql_watch_events.py
@@ -109,6 +109,24 @@ class TestSpadeWatchEvents(unittest.IsolatedAsyncioTestCase):
         mock_get_spade_url.assert_awaited_once()
         self.assertEqual(channel._spade_url, "https://spade.twitch.tv/fetched")
 
+    async def test_send_watch_returns_false_when_spade_url_fetch_fails(self):
+        from src.exceptions import MinerException
+
+        twitch = MagicMock()
+        twitch.gui.channels = MagicMock()
+        twitch._auth_state.user_id = "12345"
+        twitch.request = MagicMock(return_value=_FakeRequestCM(_FakeResponse(204)))
+        channel = Channel(twitch, id=67890, login="example_channel")
+        channel._stream = Stream(
+            channel,
+            id=24680,
+            game={"id": "13579", "name": "Example Game"},
+            viewers=100,
+            title="Example Stream",
+        )
+
+        with patch.object(Channel, "get_spade_url", AsyncMock(side_effect=MinerException("fail"))):
+            self.assertFalse(await channel.send_watch())
     async def test_send_watch_returns_false_for_non_204_status(self):
         twitch = MagicMock()
         twitch.gui.channels = MagicMock()

--- a/tests/test_gql_watch_events.py
+++ b/tests/test_gql_watch_events.py
@@ -1,52 +1,54 @@
 import base64
-import gzip
 import json
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.config.constants import GQLQuery
 from src.exceptions import RequestException
 from src.models.channel import Channel, Stream
 
 
-def _decode_gql_events(operation: GQLQuery):
-    encoded = operation["variables"]["input"]["data"]
-    return json.loads(gzip.decompress(base64.b64decode(encoded)).decode("utf8"))
+def _decode_spade_payload(payload):
+    return json.loads(base64.b64decode(payload["data"]).decode("utf8"))
 
 
-class TestGQLWatchEvents(unittest.IsolatedAsyncioTestCase):
-    def test_gql_query_wraps_gzip_base64_payload(self):
-        event_payload = [{"event": "minute-watched", "properties": {"channel": "test"}}]
-        compressed = base64.b64encode(gzip.compress(json.dumps(event_payload).encode("utf8"))).decode(
-            "utf8"
-        )
+class _FakeResponse:
+    def __init__(self, status: int):
+        self.status = status
 
-        operation = GQLQuery("mutation Example { ok }", compressed)
 
-        self.assertEqual(operation["query"], "mutation Example { ok }")
-        self.assertEqual(operation["variables"]["input"]["repository"], "twilight")
-        self.assertEqual(operation["variables"]["input"]["encoding"], "GZIP_B64")
-        self.assertEqual(_decode_gql_events(operation), event_payload)
+class _FakeRequestCM:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
 
-    def test_stream_gql_payload_contains_minute_watched_event(self):
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_stream(twitch) -> Stream:
+    channel = MagicMock(spec=Channel)
+    channel.id = 67890
+    channel._login = "example_channel"
+    channel._twitch = twitch
+    return Stream(
+        channel,
+        id=24680,
+        game={"id": "13579", "name": "Example Game"},
+        viewers=100,
+        title="Example Stream",
+    )
+
+
+class TestSpadeWatchEvents(unittest.IsolatedAsyncioTestCase):
+    def test_spade_payload_contains_minute_watched_event(self):
         twitch = MagicMock()
-        twitch._auth_state.user_id = 12345
-        channel = MagicMock(spec=Channel)
-        channel.id = 67890
-        channel._login = "example_channel"
-        channel._twitch = twitch
-        stream = Stream(
-            channel,
-            id=24680,
-            game={"id": "13579", "name": "Example Game"},
-            viewers=100,
-            title="Example Stream",
-        )
+        twitch._auth_state.user_id = "12345"
+        stream = _make_stream(twitch)
 
-        operation = stream._gql_payload
-        events = _decode_gql_events(operation)
+        events = _decode_spade_payload(stream._spade_payload)
 
-        self.assertIn("mutation SendEvents", operation["query"])
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]["event"], "minute-watched")
         properties = events[0]["properties"]
@@ -55,16 +57,21 @@ class TestGQLWatchEvents(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(properties["channel"], "example_channel")
         self.assertEqual(properties["game"], "Example Game")
         self.assertEqual(properties["game_id"], "13579")
+        self.assertEqual(properties["location"], "channel")
+        self.assertEqual(properties["player"], "site")
+        self.assertIs(properties["is_live"], True)
         self.assertEqual(properties["minutes_logged"], 1)
         self.assertEqual(properties["user_id"], 12345)
+        self.assertIsInstance(properties["user_id"], int)
         self.assertRegex(properties["client_time"], r"^\d{4}-\d{2}-\d{2}T.*Z$")
 
-    async def test_send_watch_uses_gql_and_returns_true_for_204(self):
+    async def test_send_watch_posts_to_spade_url_and_returns_true_for_204(self):
         twitch = MagicMock()
         twitch.gui.channels = MagicMock()
-        twitch._auth_state.user_id = 12345
-        twitch.gql_request = AsyncMock(return_value={"data": {"sendSpadeEvents": {"statusCode": 204}}})
+        twitch._auth_state.user_id = "12345"
+        twitch.request = MagicMock(return_value=_FakeRequestCM(_FakeResponse(204)))
         channel = Channel(twitch, id=67890, login="example_channel")
+        channel._spade_url = "https://spade.twitch.tv/"
         channel._stream = Stream(
             channel,
             id=24680,
@@ -76,7 +83,48 @@ class TestGQLWatchEvents(unittest.IsolatedAsyncioTestCase):
         result = await channel.send_watch()
 
         self.assertTrue(result)
-        twitch.gql_request.assert_awaited_once()
+        twitch.request.assert_called_once_with(
+            "POST", channel._spade_url, data=channel._stream._spade_payload
+        )
+
+    async def test_send_watch_fetches_spade_url_when_missing(self):
+        twitch = MagicMock()
+        twitch.gui.channels = MagicMock()
+        twitch._auth_state.user_id = "12345"
+        twitch.request = MagicMock(return_value=_FakeRequestCM(_FakeResponse(204)))
+        channel = Channel(twitch, id=67890, login="example_channel")
+        channel._stream = Stream(
+            channel,
+            id=24680,
+            game={"id": "13579", "name": "Example Game"},
+            viewers=100,
+            title="Example Stream",
+        )
+        with patch.object(
+            Channel, "get_spade_url", AsyncMock(return_value="https://spade.twitch.tv/fetched")
+        ) as mock_get_spade_url:
+            result = await channel.send_watch()
+
+        self.assertTrue(result)
+        mock_get_spade_url.assert_awaited_once()
+        self.assertEqual(channel._spade_url, "https://spade.twitch.tv/fetched")
+
+    async def test_send_watch_returns_false_for_non_204_status(self):
+        twitch = MagicMock()
+        twitch.gui.channels = MagicMock()
+        twitch._auth_state.user_id = "12345"
+        twitch.request = MagicMock(return_value=_FakeRequestCM(_FakeResponse(400)))
+        channel = Channel(twitch, id=67890, login="example_channel")
+        channel._spade_url = "https://spade.twitch.tv/"
+        channel._stream = Stream(
+            channel,
+            id=24680,
+            game={"id": "13579", "name": "Example Game"},
+            viewers=100,
+            title="Example Stream",
+        )
+
+        self.assertFalse(await channel.send_watch())
 
     async def test_send_watch_returns_false_without_stream(self):
         twitch = MagicMock()
@@ -85,12 +133,13 @@ class TestGQLWatchEvents(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(await channel.send_watch())
 
-    async def test_send_watch_returns_false_when_gql_request_fails(self):
+    async def test_send_watch_returns_false_when_request_fails(self):
         twitch = MagicMock()
         twitch.gui.channels = MagicMock()
-        twitch._auth_state.user_id = 12345
-        twitch.gql_request = AsyncMock(side_effect=RequestException())
+        twitch._auth_state.user_id = "12345"
+        twitch.request = MagicMock(side_effect=RequestException())
         channel = Channel(twitch, id=67890, login="example_channel")
+        channel._spade_url = "https://spade.twitch.tv/"
         channel._stream = Stream(
             channel,
             id=24680,


### PR DESCRIPTION
## Description

Drops currently don't progress: `Channel.send_watch()` reports minute-watched events through the `sendSpadeEvents` GraphQL mutation, which Twitch no longer accepts for this purpose (mirrors the same root cause described in [DevilXD/TwitchDropsMiner#1101](https://github.com/DevilXD/TwitchDropsMiner/pull/1101)).

This PR migrates watch-event reporting back to a direct POST against the Spade endpoint:

1. Consolidates the two duplicate payload builders in `src/models/channel.py` (`_spade_payload` and `_gql_payload`) into a single `_spade_payload`, adding the fields Twitch requires for drop attribution: `client_time`, `game`/`game_id`, `is_live`, `minutes_logged`, `location`, `player`, and casting `user_id` to `int`.
2. Updates `send_watch()` to `POST` that payload to `self._spade_url` (reusing the previously unused `_send_watch_spade` logic) instead of going through the GraphQL mutation.
3. Removes now-unused `GQLQuery`/`gzip` usage from `channel.py`.
4. Rewrites `tests/test_gql_watch_events.py` to cover the Spade POST path (payload contents, success/failure/missing-stream/missing-spade-url cases) instead of the old GQL path.

## Test plan

- [x] `python -m pytest tests/` — 23 passed
- [x] `ruff check src/models/channel.py tests/test_gql_watch_events.py` — clean
- [x] `mypy src/models/channel.py` — no issues