### PR TITLE
Mobile-responsive dashboard layout

### DIFF
--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1486,6 +1486,118 @@ header h1 {
     .inventory-grid {
         grid-template-columns: 1fr;
     }
+
+    /* "Selected Games" / "Available Games" were still forced side-by-side here,
+       squeezing both panels to ~180px and wrapping their headings mid-word. */
+    .games-container {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 10px;
+    }
+
+    header {
+        padding: 15px;
+    }
+
+    .header-top {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    header h1 {
+        font-size: 1.4em;
+    }
+
+    .header-controls {
+        width: 100%;
+    }
+
+    .status-bar {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        gap: 8px 12px;
+    }
+
+    .tab-button {
+        padding: 10px 6px;
+        font-size: 14px;
+    }
+
+    .panel,
+    .settings-section,
+    .inventory-filters {
+        padding: 15px;
+    }
+
+    .filter-controls {
+        gap: 10px;
+    }
+
+    .filter-search {
+        flex-wrap: wrap;
+    }
+
+    .inventory-grid {
+        column-width: 280px;
+        column-gap: 12px;
+    }
+
+    .help-content {
+        padding: 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    header h1 {
+        font-size: 1.2em;
+    }
+
+    .language-selector {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .status-bar {
+        font-size: 12px;
+    }
+
+    .mode-badge {
+        margin-left: 0;
+    }
+
+    .oauth-code {
+        font-size: 22px;
+        letter-spacing: 2px;
+        padding: 15px;
+    }
+
+    .tabs {
+        flex-wrap: wrap;
+    }
+
+    .tab-button {
+        flex: 1 1 40%;
+    }
+
+    /* column-width switches to single-column below this anyway since no card
+       fits two 280px columns at this viewport, but drop the min width so a
+       narrower phone doesn't get a horizontal scrollbar from the column box. */
+    .inventory-grid {
+        column-width: auto;
+    }
+
+    .filter-separator {
+        display: none;
+    }
+
+    #clear-filters-btn {
+        width: 100%;
+    }
 }
 
 /* Footer */


### PR DESCRIPTION
Follow-up to #59 — per your comment there, splitting out just the mobile-responsive UI piece as its own PR (the rest of that fork has diverged too much to be a clean merge, this part isn't).

Adds `@media` breakpoints at 768px and 480px so the dashboard is usable on a phone without horizontal scrolling or squeezed content:

- Header (title + language selector + status badges) stacks/wraps instead of overlapping on narrow screens
- "Selected Games" / "Available Games" in the Games to Watch section were still forced into two columns all the way down to 0px, so both panels got squeezed to a sliver and their headings wrapped mid-word — now they stack like the rest of the settings layout
- Tab bar wraps into a 2×2 grid below 480px instead of squeezing all 4 tab labels into unreadable widths
- Inventory card column width and the OAuth device-code text scale down instead of overflowing on small phones

CSS-only change, no HTML/JS touched. Verified visually at 375px (phone), 768px (tablet), and 1400px (desktop, unaffected) with the actual static files served locally.

## Test plan
- [x] 375px viewport: header, tabs, and Games to Watch panels no longer overlap/squeeze
- [x] 768px viewport: layout intact
- [x] 1400px viewport: no visual change from before