### PR TITLE
Add priority-list-only mining mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ lang/                # Translation JSON files (19 languages)
 
 - Games to watch list (auto-populated from available campaigns if empty)
 - Games can also be added manually from the web settings search box
+- Optional priority-list-only setting can restrict mining to selected games or treat selected games as priority order with other eligible campaigns as fallback
 - Connection quality multiplier
 - Language selection
 - Proxy support (including verification)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ dashboard. It sends Twitch watch events without downloading the stream itself.
 - **Low-bandwidth mining** — progresses timed drops without downloading video or audio
 - **Automatic campaign discovery** — detects active and upcoming drop campaigns
 - **Smart channel selection** — prioritizes eligible channels, preferred games, and viewers
+- **Flexible campaign mining** — either limit mining to selected games or watch all eligible campaigns with selected games prioritized
 - **Persistent sessions** — saves OAuth login state between runs
 - **Web dashboard** — manages campaigns, channels, inventory, settings, and login status
 - **Headless deployment** — runs locally, remotely, or in Docker without a desktop GUI
@@ -71,7 +72,9 @@ Then open <http://localhost:8080>.
 2. Wait for the miner to discover available campaigns.
 3. Choose the games you want to prioritize. You can also search for a game, select
    **Add Game**, and then select **Reload**.
-4. Leave the miner running while it selects eligible channels and tracks drop progress.
+4. Disable **Priority list only** in Settings if you want the selected
+   games to act as priorities instead of a strict filter.
+5. Leave the miner running while it selects eligible channels and tracks drop progress.
 
 > [!NOTE]
 > Your Twitch account must be linked to the relevant game accounts. Review your

--- a/lang/Dansk.json
+++ b/lang/Dansk.json
@@ -129,6 +129,7 @@
             "reload": "Genindlæs",
             "games_to_watch": "Spil at se",
             "games_help": "Vælg spil at se. Rækkefølgen er vigtig - træk for at ændre prioritet (top = højeste prioritet).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Søg spil...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Deutsch.json
+++ b/lang/Deutsch.json
@@ -130,6 +130,7 @@
             "reload_campaigns": "Kampagnen neu laden",
             "games_to_watch": "Spiele zum Ansehen",
             "games_help": "Wählen Sie Spiele zum Ansehen aus. Die Reihenfolge ist wichtig - ziehen Sie, um die Priorität zu ändern (oben = höchste Priorität).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Spiele suchen...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/English.json
+++ b/lang/English.json
@@ -108,6 +108,7 @@
             "reload_campaigns": "Reload Campaigns",
             "games_to_watch": "Games to Watch",
             "games_help": "Select games to watch. Order matters - drag to reorder priority (top = highest priority).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Search games...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Español.json
+++ b/lang/Español.json
@@ -130,6 +130,7 @@
             "reload_campaigns": "Recargar campañas",
             "games_to_watch": "Juegos para ver",
             "games_help": "Selecciona los juegos a ver. El orden importa - arrastra para reordenar la prioridad (arriba = mayor prioridad).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Buscar juegos...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Français.json
+++ b/lang/Français.json
@@ -130,6 +130,7 @@
             "reload_campaigns": "Recharger les campagnes",
             "games_to_watch": "Jeux à regarder",
             "games_help": "Sélectionnez les jeux à regarder. L'ordre est important - faites glisser pour réorganiser la priorité (haut = priorité la plus élevée).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Rechercher des jeux...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Indonesian.json
+++ b/lang/Indonesian.json
@@ -132,6 +132,7 @@
             "reload": "Muat Ulang",
             "games_to_watch": "Game untuk Ditonton",
             "games_help": "Pilih game untuk ditonton. Urutan penting - seret untuk mengatur ulang prioritas (atas = prioritas tertinggi).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Cari game...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Italiano.json
+++ b/lang/Italiano.json
@@ -132,6 +132,7 @@
             "reload": "Ricarica",
             "games_to_watch": "Giochi da guardare",
             "games_help": "Seleziona i giochi da guardare. L'ordine è importante - trascina per riordinare la priorità (in alto = priorità massima).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Cerca giochi...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Nederlandse.json
+++ b/lang/Nederlandse.json
@@ -132,6 +132,7 @@
             "reload": "Herladen",
             "games_to_watch": "Games om te kijken",
             "games_help": "Selecteer games om te kijken. Volgorde is belangrijk - sleep om prioriteit te wijzigen (bovenaan = hoogste prioriteit).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Zoek games...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Polski.json
+++ b/lang/Polski.json
@@ -133,6 +133,7 @@
             "reload": "Przeładuj",
             "games_to_watch": "Gry do oglądania",
             "games_help": "Wybierz gry do oglądania. Kolejność ma znaczenie - przeciągnij, aby zmienić priorytet (góra = najwyższy priorytet).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Szukaj gier...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Português.json
+++ b/lang/Português.json
@@ -132,6 +132,7 @@
             "reload": "Recarregar",
             "games_to_watch": "Jogos para assistir",
             "games_help": "Selecione os jogos para assistir. A ordem importa - arraste para reordenar a prioridade (topo = maior prioridade).",
+            "priority_list_only": "Apenas lista de prioridade (minerar somente jogos selecionados)",
             "search_games": "Procurar jogos...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Română.json
+++ b/lang/Română.json
@@ -132,6 +132,7 @@
             "reload": "Reîncarcă",
             "games_to_watch": "Jocuri de urmărit",
             "games_help": "Selectați jocurile de urmărit. Ordinea contează - trageți pentru a reordona prioritatea (sus = prioritate maximă).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Căutați jocuri...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Türkçe.json
+++ b/lang/Türkçe.json
@@ -132,6 +132,7 @@
             "reload": "Tekrar yükle",
             "games_to_watch": "İzlenecek Oyunlar",
             "games_help": "İzlenecek oyunları seçin. Sıralama önemlidir - önceliği yeniden sıralamak için sürükleyin (üst = en yüksek öncelik).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Oyun ara...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Čeština.json
+++ b/lang/Čeština.json
@@ -132,6 +132,7 @@
             "reload": "Obnovit",
             "games_to_watch": "Hry ke sledování",
             "games_help": "Vyberte hry ke sledování. Záleží na pořadí - přetáhněte pro změnu priority (nahoře = nejvyšší priorita).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Hledat hry...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Русский.json
+++ b/lang/Русский.json
@@ -133,6 +133,7 @@
             "reload": "Перезагрузить",
             "games_to_watch": "Игры для просмотра",
             "games_help": "Выберите игры для просмотра. Порядок имеет значение - перетащите для изменения приоритета (вверху = наивысший приоритет).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Поиск игр...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/Українська.json
+++ b/lang/Українська.json
@@ -132,6 +132,7 @@
             "reload": "Перезавантажити",
             "games_to_watch": "Ігри для перегляду",
             "games_help": "Виберіть ігри для перегляду. Порядок має значення - перетягніть для зміни пріоритету (вгорі = найвищий пріоритет).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "Пошук ігор...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/العربية.json
+++ b/lang/العربية.json
@@ -132,6 +132,7 @@
             "reload": "إعادة تحميل",
             "games_to_watch": "ألعاب للمشاهدة",
             "games_help": "حدد الألعاب للمشاهدة. الترتيب مهم - اسحب لإعادة ترتيب الأولوية (الأعلى = أعلى أولوية).",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "البحث عن الألعاب...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/日本語.json
+++ b/lang/日本語.json
@@ -132,6 +132,7 @@
             "reload": "再読み込み",
             "games_to_watch": "視聴するゲーム",
             "games_help": "視聴するゲームを選択してください。順序が重要です - ドラッグして優先順位を並べ替えます（上 = 最高優先度）。",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "ゲームを検索...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/简体中文.json
+++ b/lang/简体中文.json
@@ -129,6 +129,7 @@
             "reload": "刷新",
             "games_to_watch": "观看游戏",
             "games_help": "选择要观看的游戏。顺序很重要 - 拖动以重新排序优先级（顶部 = 最高优先级）。",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "搜索游戏...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/lang/繁體中文.json
+++ b/lang/繁體中文.json
@@ -132,6 +132,7 @@
             "reload": "重新載入",
             "games_to_watch": "觀看遊戲",
             "games_help": "選擇要觀看的遊戲。順序很重要 - 拖曳以重新排序優先級（頂部 = 最高優先級）。",
+            "priority_list_only": "Priority list only (mine selected games only)",
             "search_games": "搜尋遊戲...",
             "add_game": "Add Game",
             "add_game_hint": " Click \"Add Game\" to add it manually.",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -27,6 +27,7 @@ default_settings = {
     "dark_mode": False,
     "games_to_watch": [],
     "language": DEFAULT_LANG,
+    "priority_list_only": True,
     "inventory_filters": {
         "game_name_search": [],
         "show_active": False,
@@ -57,6 +58,7 @@ class Settings:
     dark_mode: bool
     games_to_watch: list[str]
     language: str
+    priority_list_only: bool
     inventory_filters: InventoryFilters
     inventory_list_view: bool
     minimum_refresh_interval_minutes: int

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -243,11 +243,12 @@ class Twitch:
                         for drop in campaign.drops:
                             if drop.can_claim:
                                 await drop.claim()
-                # figure out which games we want based on games_to_watch whitelist
+                # figure out which games we want based on selected priorities
                 self.wanted_games.clear()
                 games_to_watch: list[str] = self.settings.games_to_watch
                 next_hour: datetime = datetime.now(timezone.utc) + timedelta(hours=1)
                 logger.info("games_to_watch: %s", games_to_watch)
+                logger.info("priority_list_only: %s", self.settings.priority_list_only)
                 logger.info(
                     "inventory has %d eligible campaigns",
                     sum(1 for c in self.inventory if c.eligible),
@@ -259,7 +260,8 @@ class Twitch:
                     self._output_campaign_mapping(next_hour)
 
                 logger.info("Building wanted games list")
-                # Build wanted_games list preserving the order from games_to_watch
+                # Build wanted_games list preserving selected priority order,
+                # optionally appending all other eligible games as fallback.
                 self.wanted_games = self._stream_selector.get_wanted_games(
                     self.settings, self.inventory
                 )

--- a/src/i18n/translator.py
+++ b/src/i18n/translator.py
@@ -176,6 +176,7 @@ class GUISettings(TypedDict):
     reload_campaigns: str
     games_to_watch: str
     games_help: str
+    priority_list_only: str
     search_games: str
     add_game: str
     add_game_hint: str

--- a/src/services/stream_selector.py
+++ b/src/services/stream_selector.py
@@ -6,6 +6,80 @@ from src.models.game import Game
 
 
 class StreamSelector:
+    def _campaign_has_wanted_drops(
+        self, campaign: DropsCampaign, mining_benefits: dict[str, bool], stamp: datetime
+    ) -> bool:
+        return campaign.can_earn_within(stamp) and campaign.has_wanted_unclaimed_benefits(
+            mining_benefits
+        )
+
+    def _get_wanted_drops(
+        self, campaign: DropsCampaign, mining_benefits: dict[str, bool]
+    ) -> list[dict]:
+        wanted_drops = []
+        for drop in campaign.drops:
+            if drop.is_claimed:
+                continue
+
+            filtered_benefits = drop.get_wanted_unclaimed_benefits(mining_benefits)
+
+            if len(filtered_benefits) > 0:
+                wanted_drops.append({"name": drop.name, "benefits": filtered_benefits})
+        return wanted_drops
+
+    def _append_unlisted_games(
+        self,
+        wanted_games: list[dict],
+        settings: Settings,
+        campaigns: list[DropsCampaign],
+        stamp: datetime,
+    ) -> None:
+        if settings.priority_list_only:
+            return
+
+        selected_names = {game_name.lower() for game_name in settings.games_to_watch}
+        queued_ids = {
+            game["game_obj"].id
+            for game in wanted_games
+            if game.get("game_obj") is not None
+        }
+
+        unlisted_campaigns: dict[int, dict] = {}
+        for campaign in campaigns:
+            game = campaign.game
+            if game.name.lower() in selected_names or game.id in queued_ids:
+                continue
+            if not self._campaign_has_wanted_drops(campaign, settings.mining_benefits, stamp):
+                continue
+            if game.id not in unlisted_campaigns:
+                unlisted_campaigns[game.id] = {
+                    "game_id": game.id,
+                    "game_name": game.name,
+                    "game_icon": game.box_art_url,
+                    "game_obj": game,
+                    "campaigns": [],
+                }
+            unlisted_campaigns[game.id]["campaigns"].append(campaign)
+
+        fallback_games = sorted(
+            unlisted_campaigns.values(),
+            key=lambda game: (
+                min(campaign.ends_at for campaign in game["campaigns"]),
+                game["game_name"].lower(),
+            ),
+        )
+        for game in fallback_games:
+            game["campaigns"] = [
+                {
+                    "id": campaign.id,
+                    "name": campaign.name,
+                    "url": campaign.campaign_url,
+                    "drops": self._get_wanted_drops(campaign, settings.mining_benefits),
+                }
+                for campaign in sorted(game["campaigns"], key=lambda campaign: campaign.ends_at)
+            ]
+            wanted_games.append(game)
+
     def _get_wanted_game_tree(
         self, settings: Settings, campaigns: list[DropsCampaign]
     ) -> list[dict]:
@@ -31,18 +105,10 @@ class StreamSelector:
                 if game_obj is None:
                     game_obj = campaign.game
 
-                if not campaign.can_earn_within(next_hour):
+                if not self._campaign_has_wanted_drops(campaign, mining_benefits, next_hour):
                     continue
 
-                wanted_drops = []
-                for drop in campaign.drops:
-                    if drop.is_claimed:
-                        continue
-
-                    filtered_benefits = drop.get_wanted_unclaimed_benefits(mining_benefits)
-
-                    if len(filtered_benefits) > 0:
-                        wanted_drops.append({"name": drop.name, "benefits": filtered_benefits})
+                wanted_drops = self._get_wanted_drops(campaign, mining_benefits)
 
                 if len(wanted_drops) > 0:
                     wanted_campaigns.append(
@@ -65,6 +131,7 @@ class StreamSelector:
                     }
                 )
 
+        self._append_unlisted_games(wanted_games, settings, campaigns, next_hour)
         return wanted_games
 
     def get_wanted_game_tree(

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -71,6 +71,7 @@ class SettingsUpdate(BaseModel):
     games_to_watch: list[str] | None = None
     dark_mode: bool | None = None
     language: str | None = None
+    priority_list_only: bool | None = None
     proxy: str | None = None
     connection_quality: int | None = None
     minimum_refresh_interval_minutes: int | None = None

--- a/src/web/managers/settings.py
+++ b/src/web/managers/settings.py
@@ -75,6 +75,9 @@ class SettingsManager:
             "games_to_watch", settings_data.get("games_to_watch"), True
         )
         should_trigger_update |= self.check_and_update_setting(
+            "priority_list_only", settings_data.get("priority_list_only"), True
+        )
+        should_trigger_update |= self.check_and_update_setting(
             "dark_mode", settings_data.get("dark_mode")
         )
         should_trigger_update |= self.check_and_update_setting(

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -12,10 +12,12 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         update_data = {
             "inventory_filters": {"show_upcoming": True},
             "mining_benefits": {"BADGE": True},
+            "priority_list_only": True,
         }
         model = SettingsUpdate(**update_data)
         self.assertEqual(model.inventory_filters, update_data["inventory_filters"])
         self.assertEqual(model.mining_benefits, update_data["mining_benefits"])
+        self.assertEqual(model.priority_list_only, update_data["priority_list_only"])
 
     async def test_settings_manager_networking(self):
         # Mock dependencies
@@ -25,6 +27,7 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         mock_settings.inventory_filters = {}
         mock_settings.mining_benefits = {}
         mock_settings.games_to_watch = []
+        mock_settings.priority_list_only = False
 
         mock_console = MagicMock()
         mock_callback = MagicMock()
@@ -53,6 +56,11 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         # 3. Update Games to Watch (SHOULD trigger callback)
         games = ["Game 1"]
         manager.update_settings({"games_to_watch": games})
+        mock_callback.assert_called_once()
+        mock_callback.reset_mock()
+
+        # 4. Update Priority List Only (SHOULD trigger callback)
+        manager.update_settings({"priority_list_only": True})
         mock_callback.assert_called_once()
 
 

--- a/tests/test_wanted_games_filter.py
+++ b/tests/test_wanted_games_filter.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 from src.models.campaign import DropsCampaign
@@ -11,10 +12,30 @@ class TestWantedGamesFilter(unittest.TestCase):
         # Mock Settings
         self.settings = MagicMock()
         self.settings.games_to_watch = ["Game1", "Game2"]
+        self.settings.priority_list_only = True
         self.settings.mining_benefits = {
             "BADGE": True,
             "DIRECT_ENTITLEMENT": True,
         }  # both allowed by default
+
+    def _campaign(self, game_id, game_name, benefit_name, *, ends_in_hours=24):
+        campaign = MagicMock(spec=DropsCampaign)
+        campaign.game = Game({"id": game_id, "name": game_name})
+        campaign.can_earn_within.return_value = True
+        campaign.has_wanted_unclaimed_benefits.return_value = bool(benefit_name)
+        campaign.id = f"{game_id}-campaign"
+        campaign.name = f"{game_name} Campaign"
+        campaign.campaign_url = f"http://test.url/{game_id}"
+        campaign.ends_at = datetime.now(timezone.utc) + timedelta(hours=ends_in_hours)
+
+        drop = MagicMock()
+        drop.name = f"{game_name} Drop"
+        drop.is_claimed = False
+        drop.get_wanted_unclaimed_benefits.return_value = (
+            [benefit_name] if benefit_name else []
+        )
+        campaign.drops = [drop]
+        return campaign
 
     def test_filter_wanted_campaigns(self):
         # Setup Campaigns
@@ -97,6 +118,24 @@ class TestWantedGamesFilter(unittest.TestCase):
 
         self.assertEqual(len(wanted_games), 1)
         self.assertEqual(wanted_games[0].name, "Game1")
+
+    def test_priority_list_as_priority_appends_unlisted_games_after_priorities(self):
+        self.settings.games_to_watch = ["Priority Game"]
+        self.settings.priority_list_only = False
+
+        priority = self._campaign(1, "Priority Game", "Priority Benefit", ends_in_hours=48)
+        fallback_later = self._campaign(2, "Fallback Later", "Fallback Benefit", ends_in_hours=24)
+        fallback_earlier = self._campaign(3, "Fallback Earlier", "Fallback Benefit", ends_in_hours=2)
+
+        stream_selector = StreamSelector()
+        wanted_games = stream_selector.get_wanted_games(
+            self.settings, [fallback_later, priority, fallback_earlier]
+        )
+
+        self.assertEqual(
+            [game.name for game in wanted_games],
+            ["Priority Game", "Fallback Earlier", "Fallback Later"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_wanted_items.py
+++ b/tests/test_wanted_items.py
@@ -29,6 +29,7 @@ class TestWantedItems(unittest.TestCase):
     def test_get_wanted_tree(self):
         # Setup Settings
         self.twitch.settings.games_to_watch = ["Game1", "Game2"]
+        self.twitch.settings.priority_list_only = True
         self.twitch.settings.mining_benefits = {"BADGE": True, "DIRECT_ENTITLEMENT": False}
 
         # Setup Inventory
@@ -139,6 +140,7 @@ class TestWantedItems(unittest.TestCase):
     def test_get_wanted_tree_claimed_filtering(self):
         # Setup Settings
         self.twitch.settings.games_to_watch = ["Game1"]
+        self.twitch.settings.priority_list_only = True
         self.twitch.settings.mining_benefits = {"BADGE": True}
 
         # Setup Inventory

--- a/web/index.html
+++ b/web/index.html
@@ -190,6 +190,9 @@
                         instead of cards)
                     </label>
                     <label>
+                        <input type="checkbox" id="priority-list-only"> Priority list only
+                    </label>
+                    <label>
                         Connection Quality:
                         <input type="number" id="connection-quality" min="1" max="6" value="1">
                     </label>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -363,12 +363,10 @@ function renderChannels() {
     const gamesToWatch = state.settings.games_to_watch || [];
     const gamesToWatchSet = new Set(gamesToWatch);
 
-    // Filter channels to only include those playing games in the watch list
+    // Filter channels to selected games unless all eligible campaigns are enabled.
     const filteredChannels = channels.filter(channel => {
         const gameName = channel.game;
-        // Include channels if: they have a game AND it's in the watch list
-        // OR if the watch list is empty (show all)
-        return gamesToWatch.length === 0 || (gameName && gamesToWatchSet.has(gameName));
+        return !state.settings.priority_list_only || gamesToWatch.length === 0 || (gameName && gamesToWatchSet.has(gameName));
     });
 
     if (filteredChannels.length === 0) {
@@ -1055,6 +1053,7 @@ function updateSettingsUI(settings) {
     state.settings = settings;
     document.getElementById('dark-mode').checked = settings.dark_mode || false;
     document.getElementById('inventory-list-view').checked = settings.inventory_list_view || false;
+    document.getElementById('priority-list-only').checked = settings.priority_list_only !== false;
     applyInventoryViewMode(settings.inventory_list_view || false);
     document.getElementById('connection-quality').value = settings.connection_quality || 1;
     document.getElementById('minimum-refresh-interval').value = settings.minimum_refresh_interval_minutes || 30;
@@ -1520,6 +1519,7 @@ async function saveSettings() {
     const settings = {
         dark_mode: document.getElementById('dark-mode').checked,
         inventory_list_view: document.getElementById('inventory-list-view').checked,
+        priority_list_only: document.getElementById('priority-list-only').checked,
         language: document.getElementById('language').value,
         connection_quality: parseInt(document.getElementById('connection-quality').value),
         minimum_refresh_interval_minutes: parseInt(document.getElementById('minimum-refresh-interval').value),
@@ -1707,6 +1707,14 @@ function applyTranslations(t) {
             darkModeLabel.textContent = '';
             darkModeLabel.appendChild(checkbox);
             darkModeLabel.appendChild(document.createTextNode(' ' + t.gui.settings.general.dark_mode));
+        }
+
+        const priorityListOnlyLabel = settingsTab.querySelector('label:has(#priority-list-only)');
+        if (priorityListOnlyLabel && t.gui.settings.priority_list_only) {
+            const checkbox = priorityListOnlyLabel.querySelector('input');
+            priorityListOnlyLabel.textContent = '';
+            priorityListOnlyLabel.appendChild(checkbox);
+            priorityListOnlyLabel.appendChild(document.createTextNode(' ' + t.gui.settings.priority_list_only));
         }
 
         const connQualityLabel = settingsTab.querySelector('label:has(#connection-quality)');
@@ -1967,6 +1975,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('inventory-list-view').addEventListener('change', (e) => {
         // Apply the view mode immediately for instant feedback
         applyInventoryViewMode(e.target.checked);
+        saveSettings();
+    });
+    document.getElementById('priority-list-only').addEventListener('change', (e) => {
+        state.settings.priority_list_only = e.target.checked;
+        renderChannels();
         saveSettings();
     });
     document.getElementById('language').addEventListener('change', saveSettings);


### PR DESCRIPTION
Adds a Priority list only setting so selected games can either act as a strict mining filter or as a priority list with other eligible campaigns mined afterward.\n\nValidation:\n- uv run python -m pytest\n- uv run ruff check .