### PR TITLE
fix: correct inventory filter behavior

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -58,6 +58,11 @@ jobs:
           python-version: ${{env.PYTHON_VERSION}}
           cache: pip
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,8 @@ lang/                # Translation JSON files (19 languages)
 - Proxy support (including verification)
 - Logging and dump flags from command-line arguments
 - Persistence to JSON file (`settings.json`) in DATA_DIR
-- Inventory filters (Status, Benefit Type, Game Search)
+- Inventory filters (Status, Benefit Type, Game Search); Active/Upcoming/Expired use
+  OR semantics, Not Linked narrows the result, and Finished opts claimed campaigns in
 
 ### State Machine Flow
 
@@ -309,6 +310,7 @@ The application requires:
 - Python 3.12+
 - Virtual environment at `env/` (must be activated before running commands)
 - Dependencies from `pyproject.toml` (includes FastAPI, uvicorn, Socket.IO)
+- Node.js 24 for frontend behavior tests
 
 Docker deployment:
 
@@ -330,9 +332,10 @@ The project includes a test suite in the `tests/` directory:
 source env/bin/activate && python -m pytest tests/
 ```
 
-The suite covers settings and proxy behavior, API filtering, GraphQL watch events,
-batched channel discovery, translation consistency, frontend DOM safety, and contributor
-README automation.
+The suite covers settings and proxy behavior, inventory-filter behavior, API filtering,
+GraphQL watch events, batched channel discovery, translation consistency, frontend DOM
+safety, and contributor README automation. Inventory-filter behavior tests use Node.js;
+the validation workflow provisions Node 24 before running pytest.
 
 ### Continuous Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
-See AGENTS.md for shared repository instructions and current validation coverage, including README and contributor automation.
+See AGENTS.md for shared repository instructions and current validation coverage,
+including README, contributor automation, and inventory-filter behavior.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,2 @@
-See AGENTS.md for shared repository instructions and current validation coverage, including README and contributor automation.
+See AGENTS.md for shared repository instructions and current validation coverage,
+including README, contributor automation, and inventory-filter behavior.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Then open <http://localhost:8080>.
    **Add Game**, and then select **Reload**.
 4. Leave the miner running while it selects eligible channels and tracks drop progress.
 
+Inventory filters combine **Active**, **Upcoming**, and **Expired** as alternatives.
+**Not Linked** narrows that status result, while fully claimed campaigns stay hidden
+until **Finished** is selected.
+
 > [!NOTE]
 > Your Twitch account must be linked to the relevant game accounts. Review your
 > [Twitch Drops campaigns](https://www.twitch.tv/drops/campaigns) before mining.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -18,7 +18,7 @@ class InventoryFilters(TypedDict):
     show_benefit_other: bool
     show_expired: bool
     show_finished: bool
-    show_not_linked: bool
+    show_only_not_linked: bool
     show_upcoming: bool
 
 
@@ -36,7 +36,7 @@ default_settings = {
         "show_benefit_other": True,
         "show_expired": False,
         "show_finished": False,
-        "show_not_linked": True,
+        "show_only_not_linked": False,
         "show_upcoming": True,
     },
     "inventory_list_view": False,

--- a/src/web/managers/inventory.py
+++ b/src/web/managers/inventory.py
@@ -29,6 +29,14 @@ class InventoryManager:
         self._campaigns: dict[str, dict[str, Any]] = {}
         self._batch_mode: bool = False
 
+    @staticmethod
+    def _campaign_progress(campaign: DropsCampaign) -> dict[str, int]:
+        """Return the live drop counts used by inventory filters."""
+        return {
+            "claimed_drops": campaign.claimed_drops,
+            "total_drops": campaign.total_drops,
+        }
+
     def clear(self):
         """Clear all campaigns from inventory."""
         self._campaigns.clear()
@@ -82,8 +90,7 @@ class InventoryManager:
             "active": campaign.active,
             "upcoming": campaign.upcoming,
             "expired": campaign.expired,
-            "claimed_drops": campaign.claimed_drops,
-            "total_drops": campaign.total_drops,
+            **self._campaign_progress(campaign),
             "drops": drops_data,
         }
 
@@ -101,6 +108,9 @@ class InventoryManager:
         """
         campaign_id = drop.campaign.id
         if campaign_id in self._campaigns:
+            campaign_progress = self._campaign_progress(drop.campaign)
+            self._campaigns[campaign_id].update(campaign_progress)
+
             # Find and update the drop in the campaign
             for drop_data in self._campaigns[campaign_id]["drops"]:
                 if drop_data["id"] == drop.id:
@@ -115,7 +125,12 @@ class InventoryManager:
                     )
                     asyncio.create_task(
                         self._broadcaster.emit(
-                            "drop_update", {"campaign_id": campaign_id, "drop": drop_data}
+                            "drop_update",
+                            {
+                                "campaign_id": campaign_id,
+                                "campaign": campaign_progress,
+                                "drop": drop_data,
+                            },
                         )
                     )
                     break

--- a/src/web/managers/settings.py
+++ b/src/web/managers/settings.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from src.config.settings import default_settings
 from src.i18n.translator import _
 from src.models.game import Game
+from src.utils import merge_json
 
 
 logger = logging.getLogger("TwitchDrops")
@@ -95,9 +98,10 @@ class SettingsManager:
             "minimum_refresh_interval_minutes",
             settings_data.get("minimum_refresh_interval_minutes"),
         )
-        should_trigger_update |= self.check_and_update_setting(
-            "inventory_filters", settings_data.get("inventory_filters")
-        )
+        inventory_filters = settings_data.get("inventory_filters")
+        if inventory_filters is not None:
+            inventory_filters = self._normalize_inventory_filters(inventory_filters)
+        should_trigger_update |= self.check_and_update_setting("inventory_filters", inventory_filters)
         should_trigger_update |= self.check_and_update_setting(
             "inventory_list_view", settings_data.get("inventory_list_view")
         )
@@ -110,6 +114,17 @@ class SettingsManager:
 
         if should_trigger_update and self._on_change:
             self._on_change()
+
+    def _normalize_inventory_filters(self, updates: dict[str, Any]) -> dict[str, Any]:
+        """Merge partial filter updates and discard legacy or unknown keys."""
+        current: dict[str, Any] = copy.deepcopy(dict(self._settings.inventory_filters))
+        current.pop("show_not_linked", None)
+        current.update(updates)
+        current.pop("show_not_linked", None)
+        template = default_settings["inventory_filters"]
+        assert isinstance(template, dict)
+        merge_json(current, template)
+        return current
 
     def check_and_update_setting(
         self,

--- a/tests/test_inventory_filters.py
+++ b/tests/test_inventory_filters.py
@@ -1,0 +1,211 @@
+import asyncio
+import json
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.config.settings import default_settings
+from src.utils import merge_json
+from src.web.managers.inventory import InventoryManager
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+APP_JS = PROJECT_ROOT / "web" / "static" / "app.js"
+INDEX_HTML = PROJECT_ROOT / "web" / "index.html"
+NODE = shutil.which("node")
+
+
+def _extract_javascript_function(source: str, name: str) -> str:
+    signature = f"function {name}("
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+
+    for index in range(brace_start, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+
+    raise AssertionError(f"Could not find the end of {name}()")
+
+
+def test_inventory_filter_defaults_hide_finished_without_restricting_link_state():
+    filters = default_settings["inventory_filters"]
+
+    assert filters["show_finished"] is False
+    assert filters["show_only_not_linked"] is False
+    assert "show_not_linked" not in filters
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    input_tag = re.search(r'<input\b[^>]*\bid="filter-not-linked"[^>]*>', html)
+    assert input_tag is not None
+    assert re.search(r"\bchecked\b", input_tag.group(0)) is None
+
+
+def test_legacy_not_linked_setting_migrates_to_neutral_restriction():
+    legacy_filters = {
+        "show_not_linked": True,
+    }
+
+    merge_json(legacy_filters, default_settings["inventory_filters"])
+
+    assert "show_not_linked" not in legacy_filters
+    assert legacy_filters["show_only_not_linked"] is False
+
+
+class TestInventoryDropUpdates(unittest.IsolatedAsyncioTestCase):
+    async def test_final_claim_refreshes_campaign_counts_in_event_and_cache(self):
+        broadcaster = MagicMock()
+        broadcaster.emit = AsyncMock()
+        manager = InventoryManager(broadcaster, MagicMock())
+        manager._campaigns["campaign-1"] = {
+            "claimed_drops": 0,
+            "total_drops": 1,
+            "drops": [
+                {
+                    "id": "drop-1",
+                    "current_minutes": 29,
+                    "required_minutes": 30,
+                    "progress": 0.97,
+                    "is_claimed": False,
+                    "can_claim": False,
+                }
+            ],
+        }
+        campaign = SimpleNamespace(id="campaign-1", claimed_drops=1, total_drops=1)
+        drop = SimpleNamespace(
+            id="drop-1",
+            campaign=campaign,
+            current_minutes=30,
+            required_minutes=30,
+            progress=1.0,
+            is_claimed=True,
+            can_claim=False,
+        )
+
+        manager.update_drop(drop)
+        await asyncio.sleep(0)
+
+        campaign_data = manager._campaigns["campaign-1"]
+        assert campaign_data["claimed_drops"] == 1
+        assert campaign_data["total_drops"] == 1
+        broadcaster.emit.assert_awaited_once_with(
+            "drop_update",
+            {
+                "campaign_id": "campaign-1",
+                "campaign": {"claimed_drops": 1, "total_drops": 1},
+                "drop": campaign_data["drops"][0],
+            },
+        )
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for frontend tests")
+def test_campaign_filter_behavior_matrix():
+    function_source = _extract_javascript_function(
+        APP_JS.read_text(encoding="utf-8"), "campaignMatchesFilters"
+    )
+    base_filters = {
+        "show_active": False,
+        "show_only_not_linked": False,
+        "show_upcoming": False,
+        "show_expired": False,
+        "show_finished": False,
+        "game_name_search": [],
+        "show_benefit_item": True,
+        "show_benefit_badge": True,
+        "show_benefit_emote": True,
+        "show_benefit_other": True,
+    }
+    base_campaign = {
+        "active": False,
+        "upcoming": False,
+        "expired": False,
+        "linked": True,
+        "game_name": "Game A",
+        "total_drops": 2,
+        "claimed_drops": 0,
+        "drops": [{"benefits": [{"type": "DIRECT_ENTITLEMENT"}]}],
+    }
+
+    def case(
+        *,
+        expected: bool,
+        filter_changes: dict[str, object] | None = None,
+        campaign_changes: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return {
+            "filters": base_filters | (filter_changes or {}),
+            "campaign": base_campaign | (campaign_changes or {}),
+            "expected": expected,
+        }
+
+    cases = [
+        case(expected=True),
+        case(expected=True, campaign_changes={"linked": False}),
+        case(
+            expected=False,
+            campaign_changes={"active": True, "claimed_drops": 2},
+            filter_changes={"show_active": True},
+        ),
+        case(
+            expected=True,
+            campaign_changes={"active": True, "claimed_drops": 2},
+            filter_changes={"show_active": True, "show_finished": True},
+        ),
+        case(
+            expected=False,
+            campaign_changes={"active": True},
+            filter_changes={"show_active": True, "show_only_not_linked": True},
+        ),
+        case(
+            expected=True,
+            campaign_changes={"active": True, "linked": False},
+            filter_changes={"show_active": True, "show_only_not_linked": True},
+        ),
+        case(
+            expected=False,
+            campaign_changes={"expired": True, "linked": False},
+            filter_changes={"show_active": True, "show_only_not_linked": True},
+        ),
+        case(
+            expected=True,
+            campaign_changes={"upcoming": True},
+            filter_changes={"show_active": True, "show_upcoming": True},
+        ),
+        case(expected=False, filter_changes={"game_name_search": ["Game B"]}),
+        case(
+            expected=False,
+            filter_changes={"show_benefit_item": False, "show_benefit_badge": True},
+        ),
+    ]
+
+    script = f"""
+{function_source}
+const cases = {json.dumps(cases)};
+const results = cases.map(testCase => ({{
+    actual: campaignMatchesFilters(testCase.campaign, testCase.filters),
+    expected: testCase.expected,
+}}));
+process.stdout.write(JSON.stringify(results));
+    """
+    completed = subprocess.run(
+        [NODE, "-"],
+        check=True,
+        capture_output=True,
+        input=script,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout) == [
+        {"actual": test_case["expected"], "expected": test_case["expected"]}
+        for test_case in cases
+    ]

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -1,7 +1,8 @@
+import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
-from src.config.settings import Settings
+from src.config.settings import Settings, default_settings
 from src.web.app import SettingsUpdate
 from src.web.managers.settings import SettingsManager
 
@@ -16,6 +17,35 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         model = SettingsUpdate(**update_data)
         self.assertEqual(model.inventory_filters, update_data["inventory_filters"])
         self.assertEqual(model.mining_benefits, update_data["mining_benefits"])
+
+    async def test_inventory_filter_updates_merge_and_discard_legacy_key(self):
+        mock_broadcaster = AsyncMock()
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.inventory_filters = {
+            "game_name_search": ["Game A"],
+            "show_active": False,
+            "show_benefit_badge": True,
+            "show_benefit_emote": True,
+            "show_benefit_item": True,
+            "show_benefit_other": True,
+            "show_expired": False,
+            "show_finished": False,
+            "show_not_linked": True,
+            "show_upcoming": True,
+        }
+        manager = SettingsManager(mock_broadcaster, mock_settings, MagicMock())
+
+        manager.update_settings(
+            {"inventory_filters": {"show_active": True, "show_not_linked": True}}
+        )
+        await asyncio.sleep(0)
+
+        filters = mock_settings.inventory_filters
+        self.assertTrue(filters["show_active"])
+        self.assertEqual(filters["game_name_search"], ["Game A"])
+        self.assertFalse(filters["show_only_not_linked"])
+        self.assertNotIn("show_not_linked", filters)
+        mock_settings.save.assert_called_once()
 
     async def test_settings_manager_networking(self):
         # Mock dependencies
@@ -37,10 +67,12 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         inv_filters = {"show_upcoming": False}
         manager.update_settings({"inventory_filters": inv_filters})
         mock_callback.assert_not_called()  # inventory_filters has should_trigger_update=False
-        self.assertEqual(mock_settings.inventory_filters, inv_filters)
-        mock_console.print.assert_called_with(
-            "Setting changed: inventory_filters = {'show_upcoming': False}"
+        self.assertFalse(mock_settings.inventory_filters["show_upcoming"])
+        self.assertEqual(
+            set(mock_settings.inventory_filters),
+            set(default_settings["inventory_filters"]),
         )
+        self.assertIn("Setting changed: inventory_filters", mock_console.print.call_args.args[0])
 
         # 2. Update Mining Benefits (SHOULD trigger callback)
         benefits = {"BADGE": False}

--- a/web/index.html
+++ b/web/index.html
@@ -122,7 +122,7 @@
                             <span>Active</span>
                         </label>
                         <label class="filter-checkbox">
-                            <input type="checkbox" id="filter-not-linked" checked />
+                            <input type="checkbox" id="filter-not-linked" />
                             <span>Not Linked</span>
                         </label>
                         <label class="filter-checkbox">

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -222,7 +222,7 @@ socket.on('inventory_batch_update', (data) => {
 });
 
 socket.on('drop_update', (data) => {
-    updateDrop(data.campaign_id, data.drop);
+    updateDrop(data.campaign_id, data.drop, data.campaign);
 });
 
 socket.on('login_required', () => {
@@ -562,9 +562,11 @@ function clearInventory() {
     renderInventory();
 }
 
-function updateDrop(campaignId, dropData) {
-    if (state.campaigns[campaignId]) {
-        const drops = state.campaigns[campaignId].drops;
+function updateDrop(campaignId, dropData, campaignData = {}) {
+    const campaign = state.campaigns[campaignId];
+    if (campaign) {
+        Object.assign(campaign, campaignData);
+        const drops = campaign.drops;
         const index = drops.findIndex(d => d.id === dropData.id);
         if (index !== -1) {
             drops[index] = dropData;
@@ -579,7 +581,7 @@ function getInventoryFilters() {
     // Get filter state from UI checkboxes and selected games array
     return {
         show_active: document.getElementById('filter-active')?.checked || false,
-        show_not_linked: document.getElementById('filter-not-linked')?.checked || false,
+        show_only_not_linked: document.getElementById('filter-not-linked')?.checked || false,
         show_upcoming: document.getElementById('filter-upcoming')?.checked || false,
         show_expired: document.getElementById('filter-expired')?.checked || false,
         show_finished: document.getElementById('filter-finished')?.checked || false,
@@ -594,35 +596,24 @@ function getInventoryFilters() {
 
 
 function campaignMatchesFilters(campaign, filters) {
-    // Calculate "finished" status: all drops claimed
     const isFinished = campaign.total_drops > 0 && campaign.claimed_drops === campaign.total_drops;
 
-    // Check if any filter is enabled
     const hasGameFilter = filters.game_name_search && filters.game_name_search.length > 0;
-    const anyFilterEnabled = filters.show_active || filters.show_not_linked ||
-        filters.show_upcoming || filters.show_expired ||
-        filters.show_finished || hasGameFilter;
 
-    // If no filters enabled, show all campaigns
-    if (!anyFilterEnabled) {
-        return true;
-    }
+    // Finished campaigns are excluded unless the user explicitly includes them.
+    if (!filters.show_finished && isFinished) return false;
 
-    // Check status filters (OR logic - campaign matches if ANY checked filter applies)
-    let statusMatch = false;
+    // Link state narrows the status result instead of joining its OR group.
+    if (filters.show_only_not_linked && campaign.linked) return false;
 
-    if (filters.show_active && campaign.active) statusMatch = true;
-    if (filters.show_not_linked && !campaign.linked) statusMatch = true;
-    if (filters.show_upcoming && campaign.upcoming) statusMatch = true;
-    if (filters.show_expired && campaign.expired) statusMatch = true;
-    if (filters.show_finished && isFinished) statusMatch = true;
+    // Active, upcoming, and expired remain OR-based status filters.
+    const hasStatusFilters = filters.show_active || filters.show_upcoming || filters.show_expired;
 
-    // If status filters are enabled but campaign doesn't match any, filter it out
-    const hasStatusFilters = filters.show_active || filters.show_not_linked ||
-        filters.show_upcoming || filters.show_expired ||
-        filters.show_finished;
-    if (hasStatusFilters && !statusMatch) {
-        return false;
+    if (hasStatusFilters) {
+        const statusMatch = (filters.show_active && campaign.active) ||
+            (filters.show_upcoming && campaign.upcoming) ||
+            (filters.show_expired && campaign.expired);
+        if (!statusMatch) return false;
     }
 
     // Check game name filter (AND logic with status filters, OR logic among selected games)
@@ -1092,7 +1083,7 @@ function updateSettingsUI(settings) {
     // Restore inventory filters from settings
     if (settings.inventory_filters) {
         document.getElementById('filter-active').checked = settings.inventory_filters.show_active || false;
-        document.getElementById('filter-not-linked').checked = settings.inventory_filters.show_not_linked || false;
+        document.getElementById('filter-not-linked').checked = settings.inventory_filters.show_only_not_linked || false;
         document.getElementById('filter-upcoming').checked = settings.inventory_filters.show_upcoming || false;
         document.getElementById('filter-expired').checked = settings.inventory_filters.show_expired || false;
         document.getElementById('filter-finished').checked = settings.inventory_filters.show_finished || false;


### PR DESCRIPTION
## Summary

Supersedes the closed, unmerged #60 with the same reachable inventory-filter behavior, adapted to current `main` and hardened for existing settings.

- hides fully claimed campaigns unless **Finished** is selected
- applies **Not Linked** as an AND restriction on top of the Active/Upcoming/Expired status group
- keeps Active/Upcoming/Expired OR-based
- migrates the old persisted `show_not_linked` setting without silently reinterpreting existing users' saved `true` value
- refreshes campaign claim counts on live drop updates so newly finished campaigns disappear immediately
- documents the behavior and adds backend/frontend regression coverage

The dead `show_linked` condition from #60 is intentionally omitted because no Linked setting or UI control exists.

Closes #51
Closes #52

## Validation

- `python -W error::RuntimeWarning -m pytest tests/ -q` — 44 passed
- `ruff check src tests` — passed
- `mypy src/` — passed (55 source files)
- `node --check web/static/app.js` — passed
- 19 language JSON files validated
- `actionlint` 1.7.12 — passed
- `git diff --check` — passed

## Known baseline issue

`uv lock --check` remains blocked by a pre-existing mismatch on `main`: `pyproject.toml` is version 1.2.5 while `uv.lock` still records 1.2.4. This PR does not include that unrelated lockfile correction.