### PR TITLE
fix: keep release versions synchronized

### DIFF
--- a/.github/scripts/create_release.sh
+++ b/.github/scripts/create_release.sh
@@ -10,9 +10,11 @@
 # This script:
 #   1. Updates src/version.py with the new version
 #   2. Updates pyproject.toml with the new version
-#   3. Commits and pushes changes to current branch
-#   4. Creates a new release branch
-#   5. Creates and pushes a version tag
+#   3. Regenerates uv.lock with the new project version
+#   4. Validates all version sources match
+#   5. Commits and pushes changes to current branch
+#   6. Creates a new release branch
+#   7. Creates and pushes a version tag
 #
 # Expected to be called from GitHub Actions after version validation
 
@@ -42,9 +44,17 @@ echo "__version__ = \"$VERSION\"" > src/version.py
 echo "Updating pyproject.toml..."
 sed -i "s/^version = \"[^\"]*\"\(.*\)/version = \"$VERSION\"\1/" pyproject.toml
 
+# Regenerate the lockfile so its editable project metadata matches the release.
+echo "Updating uv.lock..."
+uv lock
+
+# Fail before committing, branching, or tagging if any version source drifted.
+echo "Validating version sources..."
+"$(dirname "$0")/extract_version.sh"
+
 # Commit changes
 echo "Committing version changes..."
-git add src/version.py pyproject.toml
+git add src/version.py pyproject.toml uv.lock
 git commit -m "chore: bump version to $VERSION"
 git push origin "$CURRENT_BRANCH"
 

--- a/.github/scripts/extract_version.sh
+++ b/.github/scripts/extract_version.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Script: extract_version.sh
-# Description: Extracts and validates version from branch name and/or project files
+# Description: Extracts and validates the version from the branch and project metadata
 # Usage: extract_version.sh [branch_name]
 
 # Color codes for output
@@ -14,8 +14,8 @@ NC='\033[0m' # No Color
 usage() {
     echo "Usage: $0 [branch_name]"
     echo ""
-    echo "Mode 1 (with branch name): Validates version from branch matches src/version.py and pyproject.toml"
-    echo "Mode 2 (no branch name): Validates src/version.py and pyproject.toml versions match"
+    echo "Mode 1 (with branch name): Validates branch, src/version.py, pyproject.toml, and uv.lock"
+    echo "Mode 2 (no branch name): Validates all project version sources match"
     echo ""
     echo "Examples:"
     echo "  $0 release/1.2.3          # Validate branch version matches files"
@@ -42,16 +42,29 @@ fi
 VERSION_TOML=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
 echo "pyproject.toml version: $VERSION_TOML"
 
+# Read the editable project version from uv.lock.
+if [ ! -f "uv.lock" ]; then
+    echo -e "${RED}Error: uv.lock not found${NC}"
+    exit 1
+fi
+VERSION_LOCK=$(grep -A2 '^name = "twitch-drops-miner"$' uv.lock | grep -m1 -oP '^version = "\K[^"]+' || true)
+if [ -z "$VERSION_LOCK" ]; then
+    echo -e "${RED}Error: Twitch Drops Miner version not found in uv.lock${NC}"
+    exit 1
+fi
+echo "uv.lock version: $VERSION_LOCK"
+
 # Check if branch name argument is provided
 if [ $# -eq 0 ]; then
     # Mode 2: No branch name - just validate files match
     echo ""
     echo "No branch name provided - validating file versions match..."
 
-    if [ "$VERSION_PY" != "$VERSION_TOML" ]; then
+    if [ "$VERSION_PY" != "$VERSION_TOML" ] || [ "$VERSION_PY" != "$VERSION_LOCK" ]; then
         echo -e "${RED}Error: Version mismatch between files:${NC}"
         echo -e "${RED}  src/version.py:   $VERSION_PY${NC}"
         echo -e "${RED}  pyproject.toml:   $VERSION_TOML${NC}"
+        echo -e "${RED}  uv.lock:          $VERSION_LOCK${NC}"
         exit 1
     fi
 
@@ -68,12 +81,15 @@ else
     echo "Branch version: $BRANCH_VERSION"
     echo ""
 
-    # Check all three versions match
-    if [ "$BRANCH_VERSION" != "$VERSION_PY" ] || [ "$BRANCH_VERSION" != "$VERSION_TOML" ]; then
+    # Check the branch and all project version sources match.
+    if [ "$BRANCH_VERSION" != "$VERSION_PY" ] || \
+       [ "$BRANCH_VERSION" != "$VERSION_TOML" ] || \
+       [ "$BRANCH_VERSION" != "$VERSION_LOCK" ]; then
         echo -e "${RED}Error: Version mismatch detected:${NC}"
         echo -e "${RED}  Branch:           $BRANCH_VERSION${NC}"
         echo -e "${RED}  src/version.py:   $VERSION_PY${NC}"
         echo -e "${RED}  pyproject.toml:   $VERSION_TOML${NC}"
+        echo -e "${RED}  uv.lock:          $VERSION_LOCK${NC}"
         exit 1
     fi
 

--- a/.github/scripts/revert_release.sh
+++ b/.github/scripts/revert_release.sh
@@ -11,12 +11,12 @@
 #   2. Checks what resources exist (tag, branch, GitHub release)
 #   3. Extracts the previous version from git history
 #   4. Shows a summary and asks for confirmation
-#   5. Deletes the tag, branch, and GitHub release
-#   6. Reverts version.py and pyproject.toml to the previous version
-#   7. Commits and pushes the revert to main branch
+#   5. Prepares, validates, and pushes the version rollback
+#   6. Deletes the tag, branch, and GitHub release
 #
 # Requirements:
 #   - gh CLI installed and authenticated
+#   - uv installed
 #   - Git repository with proper remotes configured
 #   - Write access to the repository
 
@@ -77,8 +77,10 @@ fi
 echo -e "${GREEN}✓ Version format is valid${NC}"
 echo ""
 
-# Step 2: Check if gh CLI is installed and authenticated
-echo -e "${YELLOW}[2/7] Checking GitHub CLI...${NC}"
+# Step 2: Check prerequisites and refresh the repository before inspecting
+# release history. This prevents a stale clone from selecting the wrong
+# previous version.
+echo -e "${YELLOW}[2/7] Checking prerequisites and refreshing main...${NC}"
 if ! command -v gh &> /dev/null; then
     echo -e "${RED}Error: gh CLI is not installed${NC}"
     echo -e "${RED}Please install it from: https://cli.github.com/${NC}"
@@ -91,6 +93,27 @@ if ! gh auth status &>/dev/null; then
     exit 1
 fi
 echo -e "${GREEN}✓ GitHub CLI is ready${NC}"
+
+if ! command -v uv &> /dev/null; then
+    echo -e "${RED}Error: uv is not installed${NC}"
+    echo -e "${RED}Please install it from: https://docs.astral.sh/uv/${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ uv is ready${NC}"
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "${RED}Error: Working tree must be clean before reverting a release${NC}"
+    exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "  Switching to main branch..."
+    git checkout main
+fi
+git pull --ff-only origin main
+git fetch --tags origin
+echo -e "${GREEN}✓ Repository history is current${NC}"
 echo ""
 
 # Step 3: Check what resources exist
@@ -163,6 +186,20 @@ if ! PREVIOUS_VERSION=$("$SCRIPT_DIR/get_previous_version.sh" "$VERSION" 2>&1); 
 fi
 
 echo -e "${GREEN}✓ Previous version: $PREVIOUS_VERSION${NC}"
+
+# Validate current metadata and reject attempts to roll back an older release.
+"$SCRIPT_DIR/extract_version.sh" >/dev/null
+CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/version.py)
+if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+    ROLLBACK_REQUIRED=true
+elif [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+    ROLLBACK_REQUIRED=false
+    echo -e "${YELLOW}  Main is already at $PREVIOUS_VERSION; cleanup-only retry${NC}"
+else
+    echo -e "${RED}Error: main is at $CURRENT_VERSION, not $VERSION or $PREVIOUS_VERSION${NC}"
+    echo -e "${RED}Refusing to revert a non-current historical release${NC}"
+    exit 1
+fi
 echo ""
 
 # Step 5: Show summary and ask for confirmation
@@ -203,12 +240,17 @@ if [ "$BRANCH_EXISTS_LOCAL" = true ]; then
     ACTION_COUNT=$((ACTION_COUNT + 1))
 fi
 
-echo "  • Update src/version.py: $VERSION → $PREVIOUS_VERSION"
-echo "  • Update pyproject.toml: $VERSION → $PREVIOUS_VERSION"
-echo "  • Commit changes to main branch with message:"
-echo "    'chore: revert version from $VERSION to $PREVIOUS_VERSION'"
-echo "  • Push changes to origin/main"
-ACTION_COUNT=$((ACTION_COUNT + 3))
+if [ "$ROLLBACK_REQUIRED" = true ]; then
+    echo "  • Update src/version.py: $VERSION → $PREVIOUS_VERSION"
+    echo "  • Update pyproject.toml: $VERSION → $PREVIOUS_VERSION"
+    echo "  • Regenerate uv.lock for $PREVIOUS_VERSION"
+    echo "  • Commit changes to main branch with message:"
+    echo "    'chore: revert version from $VERSION to $PREVIOUS_VERSION'"
+    echo "  • Push changes to origin/main"
+    ACTION_COUNT=$((ACTION_COUNT + 3))
+else
+    echo "  • Keep main at its already-restored version: $PREVIOUS_VERSION"
+fi
 
 echo ""
 echo -e "${RED}Total actions: $ACTION_COUNT${NC}"
@@ -227,8 +269,50 @@ echo ""
 echo -e "${GREEN}Confirmed. Proceeding with revert...${NC}"
 echo ""
 
-# Step 6: Perform revert operations
-echo -e "${YELLOW}[5/7] Deleting release resources...${NC}"
+# Step 6: Prepare, validate, and publish the version rollback before deleting
+# release resources. If any local preparation or push fails, the published
+# release remains intact and can still be recovered or retried safely.
+echo -e "${YELLOW}[5/7] Preparing version rollback...${NC}"
+
+if [ "$ROLLBACK_REQUIRED" = true ]; then
+    git config user.name "github-actions[bot]" || true
+    git config user.email "github-actions[bot]@users.noreply.github.com" || true
+
+    echo "  Updating src/version.py..."
+    echo "__version__ = \"$PREVIOUS_VERSION\"" > src/version.py
+    echo -e "${GREEN}✓ Updated src/version.py${NC}"
+
+    echo "  Updating pyproject.toml..."
+    sed -i "s/^version = \"[^\"]*\"\(.*\)/version = \"$PREVIOUS_VERSION\"\1/" pyproject.toml
+    echo -e "${GREEN}✓ Updated pyproject.toml${NC}"
+
+    echo "  Updating uv.lock..."
+    uv lock
+    "$SCRIPT_DIR/extract_version.sh"
+    echo -e "${GREEN}✓ Updated uv.lock${NC}"
+
+    git add src/version.py pyproject.toml uv.lock
+    echo "  Creating rollback commit..."
+    git commit -m "chore: revert version from $VERSION to $PREVIOUS_VERSION"
+    echo -e "${GREEN}✓ Created rollback commit${NC}"
+
+    echo "  Pushing rollback to origin/main..."
+    git push origin main
+    echo -e "${GREEN}✓ Published rollback${NC}"
+else
+    echo -e "${GREEN}✓ Main already advertises $PREVIOUS_VERSION${NC}"
+fi
+echo ""
+
+# Step 7: Delete release resources only after the rollback is published.
+echo -e "${YELLOW}[6/7] Deleting release resources...${NC}"
+
+CLEANUP_FAILED=false
+RELEASE_DELETE_OK=true
+REMOTE_TAG_DELETE_OK=true
+LOCAL_TAG_DELETE_OK=true
+REMOTE_BRANCH_DELETE_OK=true
+LOCAL_BRANCH_DELETE_OK=true
 
 # Delete GitHub release
 if [ "$RELEASE_EXISTS" = true ]; then
@@ -237,6 +321,8 @@ if [ "$RELEASE_EXISTS" = true ]; then
         echo -e "${GREEN}✓ Deleted GitHub release${NC}"
     else
         echo -e "${RED}✗ Failed to delete GitHub release${NC}"
+        RELEASE_DELETE_OK=false
+        CLEANUP_FAILED=true
     fi
 fi
 
@@ -247,6 +333,8 @@ if [ "$TAG_EXISTS_REMOTE" = true ]; then
         echo -e "${GREEN}✓ Deleted remote tag${NC}"
     else
         echo -e "${RED}✗ Failed to delete remote tag (may have been deleted by release deletion)${NC}"
+        REMOTE_TAG_DELETE_OK=false
+        CLEANUP_FAILED=true
     fi
 fi
 
@@ -257,6 +345,8 @@ if [ "$TAG_EXISTS_LOCAL" = true ]; then
         echo -e "${GREEN}✓ Deleted local tag${NC}"
     else
         echo -e "${RED}✗ Failed to delete local tag${NC}"
+        LOCAL_TAG_DELETE_OK=false
+        CLEANUP_FAILED=true
     fi
 fi
 
@@ -267,6 +357,8 @@ if [ "$BRANCH_EXISTS_REMOTE" = true ]; then
         echo -e "${GREEN}✓ Deleted remote branch${NC}"
     else
         echo -e "${RED}✗ Failed to delete remote branch${NC}"
+        REMOTE_BRANCH_DELETE_OK=false
+        CLEANUP_FAILED=true
     fi
 fi
 
@@ -282,68 +374,39 @@ if [ "$BRANCH_EXISTS_LOCAL" = true ]; then
         echo -e "${GREEN}✓ Deleted local branch${NC}"
     else
         echo -e "${RED}✗ Failed to delete local branch${NC}"
+        LOCAL_BRANCH_DELETE_OK=false
+        CLEANUP_FAILED=true
     fi
 fi
 
 echo ""
 
-# Step 7: Update version files and commit
-echo -e "${YELLOW}[6/7] Updating version files...${NC}"
-
-# Make sure we're on main branch
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$CURRENT_BRANCH" != "main" ]; then
-    echo "  Switching to main branch..."
-    git checkout main
-    git pull origin main
-fi
-
-# Configure git
-git config user.name "github-actions[bot]" || true
-git config user.email "github-actions[bot]@users.noreply.github.com" || true
-
-# Update version.py
-echo "  Updating src/version.py..."
-echo "__version__ = \"$PREVIOUS_VERSION\"" > src/version.py
-echo -e "${GREEN}✓ Updated src/version.py${NC}"
-
-# Update pyproject.toml
-echo "  Updating pyproject.toml..."
-sed -i "s/^version = \"[^\"]*\"\(.*\)/version = \"$PREVIOUS_VERSION\"\1/" pyproject.toml
-echo -e "${GREEN}✓ Updated pyproject.toml${NC}"
-
-echo ""
-
-# Step 8: Commit and push
-echo -e "${YELLOW}[7/7] Committing and pushing changes...${NC}"
-
-git add src/version.py pyproject.toml
-
-if git diff --cached --quiet; then
-    echo -e "${YELLOW}  No changes to commit (version may already be reverted)${NC}"
+# Step 8: Report completion
+echo -e "${YELLOW}[7/7] Finalizing...${NC}"
+echo -e "${BLUE}=====================================${NC}"
+if [ "$CLEANUP_FAILED" = true ]; then
+    echo -e "${RED}Revert published with cleanup errors${NC}"
 else
-    echo "  Creating commit..."
-    git commit -m "chore: revert version from $VERSION to $PREVIOUS_VERSION"
-    echo -e "${GREEN}✓ Created commit${NC}"
-
-    echo "  Pushing to origin/main..."
-    git push origin main
-    echo -e "${GREEN}✓ Pushed changes${NC}"
+    echo -e "${GREEN}Revert Complete!${NC}"
 fi
-
-echo ""
-echo -e "${BLUE}=====================================${NC}"
-echo -e "${GREEN}✅ Revert Complete!${NC}"
 echo -e "${BLUE}=====================================${NC}"
 echo ""
-echo -e "${GREEN}Successfully reverted version from $VERSION to $PREVIOUS_VERSION${NC}"
+if [ "$ROLLBACK_REQUIRED" = true ]; then
+    echo -e "${GREEN}Reverted version from $VERSION to $PREVIOUS_VERSION${NC}"
+else
+    echo -e "${GREEN}Main was already at $PREVIOUS_VERSION${NC}"
+fi
 echo ""
 echo "Summary:"
-[ "$RELEASE_EXISTS" = true ] && echo "  ✓ Deleted GitHub release"
-[ "$TAG_EXISTS_REMOTE" = true ] && echo "  ✓ Deleted remote tag"
-[ "$TAG_EXISTS_LOCAL" = true ] && echo "  ✓ Deleted local tag"
-[ "$BRANCH_EXISTS_REMOTE" = true ] && echo "  ✓ Deleted remote branch"
-[ "$BRANCH_EXISTS_LOCAL" = true ] && echo "  ✓ Deleted local branch"
-echo "  ✓ Reverted version files"
-echo "  ✓ Committed and pushed to main"
+[ "$RELEASE_EXISTS" = true ] && [ "$RELEASE_DELETE_OK" = true ] && echo "  ✓ Deleted GitHub release"
+[ "$TAG_EXISTS_REMOTE" = true ] && [ "$REMOTE_TAG_DELETE_OK" = true ] && echo "  ✓ Deleted remote tag"
+[ "$TAG_EXISTS_LOCAL" = true ] && [ "$LOCAL_TAG_DELETE_OK" = true ] && echo "  ✓ Deleted local tag"
+[ "$BRANCH_EXISTS_REMOTE" = true ] && [ "$REMOTE_BRANCH_DELETE_OK" = true ] && echo "  ✓ Deleted remote branch"
+[ "$BRANCH_EXISTS_LOCAL" = true ] && [ "$LOCAL_BRANCH_DELETE_OK" = true ] && echo "  ✓ Deleted local branch"
+[ "$ROLLBACK_REQUIRED" = true ] && echo "  ✓ Reverted, committed, and pushed version files"
 echo ""
+
+if [ "$CLEANUP_FAILED" = true ]; then
+    echo -e "${RED}One or more release resources could not be deleted. Retry cleanup before continuing.${NC}"
+    exit 1
+fi

--- a/.github/scripts/test/README.md
+++ b/.github/scripts/test/README.md
@@ -10,10 +10,13 @@ Run all test suites:
 
 ```bash
 # Run semver validation tests
-.github/scripts/test/test_validate_semver.sh
+bash .github/scripts/test/test_validate_semver.sh
 
 # Run GitHub Actions output tests
-.github/scripts/test/test_github_output.sh
+bash .github/scripts/test/test_github_output.sh
+
+# Run project-version consistency tests
+bash .github/scripts/test/test_extract_version.sh
 ```
 
 ### Test validate_semver.sh
@@ -106,6 +109,12 @@ Tests failed:       0
 
 - `0` - All tests passed
 - `1` - One or more tests failed
+
+### Test extract_version.sh
+
+`test_extract_version.sh` verifies matching file and release-branch versions, rejects
+drift in `src/version.py`, `pyproject.toml`, or `uv.lock`, and checks the GitHub Actions
+outputs used by the release workflows.
 
 ## Adding New Tests
 

--- a/.github/scripts/test/test_extract_version.sh
+++ b/.github/scripts/test/test_extract_version.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(dirname "$TEST_DIR")"
+SCRIPT="$SCRIPT_DIR/extract_version.sh"
+TEMP_DIR=$(mktemp -d)
+FIXTURE_DIR="$TEMP_DIR/repository"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+reset_fixture() {
+    rm -rf "$FIXTURE_DIR"
+    mkdir -p "$FIXTURE_DIR/src"
+    printf '__version__ = "1.2.5"\n' > "$FIXTURE_DIR/src/version.py"
+    printf '[project]\nname = "twitch-drops-miner"\nversion = "1.2.5"\n' \
+        > "$FIXTURE_DIR/pyproject.toml"
+    printf 'version = 1\n\n[[package]]\nname = "twitch-drops-miner"\nversion = "1.2.5"\nsource = { editable = "." }\n' \
+        > "$FIXTURE_DIR/uv.lock"
+}
+
+expect_success() {
+    local description="$1"
+    shift
+    if (cd "$FIXTURE_DIR" && bash "$SCRIPT" "$@" >/dev/null); then
+        echo "PASS: $description"
+    else
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+}
+
+expect_failure() {
+    local description="$1"
+    shift
+    if (cd "$FIXTURE_DIR" && bash "$SCRIPT" "$@" >/dev/null 2>&1); then
+        echo "FAIL: $description unexpectedly passed" >&2
+        exit 1
+    else
+        echo "PASS: $description"
+    fi
+}
+
+reset_fixture
+expect_success "matching project files"
+expect_success "matching release branch" "release/1.2.5"
+
+reset_fixture
+sed -i 's/1.2.5/1.2.4/' "$FIXTURE_DIR/src/version.py"
+expect_failure "src/version.py mismatch"
+
+reset_fixture
+sed -i 's/1.2.5/1.2.4/' "$FIXTURE_DIR/pyproject.toml"
+expect_failure "pyproject.toml mismatch"
+
+reset_fixture
+sed -i 's/1.2.5/1.2.4/' "$FIXTURE_DIR/uv.lock"
+expect_failure "uv.lock mismatch"
+
+reset_fixture
+rm "$FIXTURE_DIR/uv.lock"
+expect_failure "missing uv.lock"
+
+reset_fixture
+expect_failure "release branch mismatch" "release/1.2.6"
+
+reset_fixture
+OUTPUT_FILE="$TEMP_DIR/github-output.txt"
+(cd "$FIXTURE_DIR" && GITHUB_OUTPUT="$OUTPUT_FILE" bash "$SCRIPT" >/dev/null)
+grep -qx 'version=1.2.5' "$OUTPUT_FILE"
+grep -qx 'is_prerelease=false' "$OUTPUT_FILE"
+echo "PASS: GitHub Actions outputs"
+
+echo "All extract_version.sh tests passed."

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -68,8 +68,20 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
 
+      - name: Check uv lockfile
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Validate uv lockfile
+        run: uv lock --check
+
       - name: Run Python tests
         run: python -m pytest tests/
+
+      - name: Run release script tests
+        run: |
+          bash .github/scripts/test/test_validate_semver.sh
+          bash .github/scripts/test/test_github_output.sh
+          bash .github/scripts/test/test_extract_version.sh
 
   validate:
     name: Validate Language Files

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -26,6 +26,9 @@ jobs:
           token: ${{ secrets.PUBLISHER_TOKEN }}
           fetch-depth: 0
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       - name: Extract version
         id: extract
         run: .github/scripts/extract_version.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,12 +335,14 @@ source env/bin/activate && python -m pytest tests/
 The suite covers settings and proxy behavior, inventory-filter behavior, API filtering,
 GraphQL watch events, batched channel discovery, translation consistency, frontend DOM
 safety, and contributor README automation. Inventory-filter behavior tests use Node.js;
-the validation workflow provisions Node 24 before running pytest.
+the validation workflow provisions Node 24 before running pytest. It also runs the release
+script contract tests under `.github/scripts/test/`.
 
 ### Continuous Integration
 
 - `.github/workflows/validation.yml` runs Ruff, Mypy, the Python test suite, language
-  JSON validation, and Docker build validation for pull requests and pushes to `main`.
+  JSON validation, `uv lock --check`, release-script tests, and Docker build validation
+  for pull requests and pushes to `main`.
 - `.github/workflows/contributors.yml` credits the human author of each pull request
   merged into `main`, including linked pull request numbers in the alphabetically sorted
   Contributors table in `README.md`.
@@ -350,6 +352,9 @@ the validation workflow provisions Node 24 before running pytest.
 - Keep the contributor table header and the `<!-- contributors:start -->` and
   `<!-- contributors:end -->` markers in `README.md`; the updater fails closed if the
   table header or either marker is missing, duplicated, or malformed.
+- `.github/workflows/version-release.yml` is the release entry point. It must provision
+  `uv`, update `src/version.py`, `pyproject.toml`, and `uv.lock` together, and validate all
+  three before creating a release branch or tag.
 
 
 ### Manual Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,2 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
-including README, contributor automation, and inventory-filter behavior.
+including README, contributor and release automation, and inventory-filter behavior.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,2 +1,2 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
-including README, contributor automation, and inventory-filter behavior.
+including README, contributor and release automation, and inventory-filter behavior.

--- a/README.md
+++ b/README.md
@@ -169,4 +169,5 @@ This fork is maintained with AI-assisted development tools. Changes are validate
 automated tests and code-quality checks, but users should still review updates before
 deploying them. The validation suite includes GraphQL watch events and batched channel
 discovery, alongside settings, translation, and frontend safety checks. Use the software
-responsibly.
+responsibly. Release automation verifies that the runtime, package, and lockfile versions
+match before publishing tags and Docker images.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This patch release makes inventory filtering more predictable and keeps version 
 ### 🔗 Issues and Pull Requests
 - Resolved [#51](https://github.com/rangermix/TwitchDropsMiner/issues/51) and [#52](https://github.com/rangermix/TwitchDropsMiner/issues/52) in [#79](https://github.com/rangermix/TwitchDropsMiner/pull/79).
 - PR #79 supersedes the earlier, closed [#60](https://github.com/rangermix/TwitchDropsMiner/pull/60).
+- Release-version consistency and rollback safety were fixed in [#80](https://github.com/rangermix/TwitchDropsMiner/pull/80).
 
 ### 🙌 Contributors
 - [@rangermix](https://github.com/rangermix) — implementation, migration, tests, and release maintenance.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+# Release Notes - v1.2.6
+
+This patch release makes inventory filtering more predictable and keeps version metadata synchronized across source and packaged installations.
+
+### 🐛 Inventory Filter Fixes
+- **Finished Campaigns**: Fully claimed campaigns now stay hidden until the **Finished** filter is selected.
+- **Not Linked Filtering**: **Not Linked** now narrows the selected campaign statuses instead of broadening them, so combinations such as **Active + Not Linked** behave as expected.
+- **Live Completion Updates**: Campaigns disappear as soon as their final drop is claimed instead of waiting for an inventory reload.
+- **Settings Compatibility**: Existing saved filter settings migrate safely without unexpectedly restricting the inventory.
+
+### ⚙️ Release Reliability
+- **Consistent Versions**: Release automation now updates and validates `src/version.py`, `pyproject.toml`, and `uv.lock` together before publishing a tag or Docker image.
+- **Expanded Validation**: Release-script contracts and frontend filter behavior now run in continuous integration.
+
+### 🔗 Issues and Pull Requests
+- Resolved [#51](https://github.com/rangermix/TwitchDropsMiner/issues/51) and [#52](https://github.com/rangermix/TwitchDropsMiner/issues/52) in [#79](https://github.com/rangermix/TwitchDropsMiner/pull/79).
+- PR #79 supersedes the earlier, closed [#60](https://github.com/rangermix/TwitchDropsMiner/pull/60).
+
+### 🙌 Contributors
+- [@rangermix](https://github.com/rangermix) — implementation, migration, tests, and release maintenance.
+- [@SimpliAj](https://github.com/SimpliAj) — original Inventory-filter proposal in PR #60.
+
 # Release Notes - v1.2.5
 
 This update brings a major boost to drop progress reliability, a fresh look for your inventory, and significant improvements to the mobile experience. We’ve also streamlined our development pipeline to ensure faster and more stable future updates.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,6 @@
 """TwitchDropsMiner - Modular source package."""
 
-__version__ = "1.0.0"
+from src.version import __version__
+
+
+__all__ = ["__version__"]

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -12,6 +12,8 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from src.version import __version__
+
 
 if TYPE_CHECKING:
     import uvicorn
@@ -23,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("TwitchDrops")
 
 # Create FastAPI app
-app = FastAPI(title="Twitch Drops Miner Web", version="1.0.0")
+app = FastAPI(title="Twitch Drops Miner Web", version=__version__)
 
 # Add CORS middleware
 app.add_middleware(

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,57 @@
+import re
+from pathlib import Path
+
+import tomllib
+
+import src
+from src.version import __version__
+from src.web.app import app
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_all_project_version_sources_match():
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    lockfile = tomllib.loads((PROJECT_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked_projects = [
+        package
+        for package in lockfile["package"]
+        if package["name"] == pyproject["project"]["name"]
+    ]
+
+    assert len(locked_projects) == 1
+    assert pyproject["project"]["version"] == __version__
+    assert locked_projects[0]["version"] == __version__
+    assert src.__version__ == __version__
+    assert app.version == __version__
+
+
+def test_release_scripts_update_and_stage_lockfile():
+    for script_name in ("create_release.sh", "revert_release.sh"):
+        script = (
+            PROJECT_ROOT / ".github" / "scripts" / script_name
+        ).read_text(encoding="utf-8")
+
+        assert re.search(r"^\s*uv lock$", script, re.MULTILINE)
+        assert re.search(
+            r"^\s*git add src/version\.py pyproject\.toml uv\.lock$",
+            script,
+            re.MULTILINE,
+        )
+
+
+def test_release_rollback_is_published_before_destructive_cleanup():
+    script = (PROJECT_ROOT / ".github" / "scripts" / "revert_release.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "command -v uv" in script
+    assert script.index("git pull --ff-only origin main") < script.index(
+        'PREVIOUS_VERSION=$("$SCRIPT_DIR/get_previous_version.sh"'
+    )
+    assert script.index("git push origin main") < script.index(
+        'gh release delete "$TAG_NAME" --yes'
+    )
+    assert 'Refusing to revert a non-current historical release' in script
+    assert "CLEANUP_FAILED=true" in script

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "twitch-drops-miner"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- repair the existing 1.2.5 mismatch in `uv.lock` and expose one canonical runtime/API version
- update release and rollback automation to regenerate, validate, and stage all version sources safely
- enforce lockfile and release-script consistency in CI
- pre-seed reviewed v1.2.6 release notes for the inventory-filter patch

## Why
The v1.2.5 release updated `src/version.py` and `pyproject.toml`, but left the editable project entry in `uv.lock` at 1.2.4. The release script did not update or validate the lockfile, so the same mismatch would recur on every release.

The rollback path is also hardened so it refreshes history before deriving the prior version, refuses historical-release downgrades, publishes the rollback before destructive cleanup, and reports cleanup failures accurately.

## Validation
- `python -W error::RuntimeWarning -m pytest tests/ -q` (47 passed)
- `python -m ruff check src tests`
- `python -m mypy src`
- all release shell test suites
- `uv lock --check`
- `actionlint` on all workflows
- Node syntax and all language JSON files
- fresh-cache release-lock simulation