### PR TITLE
Fix inventory filters, watched channels, and Hungarian locale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,12 @@ src/
 ├── version.py       # Version string
 └── __main__.py      # Entry point
 
-lang/                # Translation JSON files (19 languages)
+lang/                # Translation JSON files (20 languages)
 ├── English.json     # Default/fallback translations
 ├── Español.json
 ├── Français.json
 ├── Deutsch.json
-└── ...              # 15 more languages
+└── ...              # 16 more languages
 ```
 
 ### Core Components
@@ -153,7 +153,9 @@ lang/                # Translation JSON files (19 languages)
 - Logging and dump flags from command-line arguments
 - Persistence to JSON file (`settings.json`) in DATA_DIR
 - Inventory filters (Status, Benefit Type, Game Search); Active/Upcoming/Expired use
-  OR semantics, Not Linked narrows the result, and Finished opts claimed campaigns in
+  OR semantics, Not Linked narrows the result, and Finished opts claimed campaigns in.
+  Zero-minute subscription rewards are omitted from Inventory and Wanted Drops Queue;
+  the actively watched channel remains visible while game settings are changing
 
 ### State Machine Flow
 
@@ -216,7 +218,7 @@ Runs in background to trigger:
 
 **Architecture:**
 
-- All translations stored as JSON files in `lang/` directory (19 languages supported)
+- All translations stored as JSON files in `lang/` directory (20 languages supported)
 - English (`lang/English.json`) is the single source of truth and fallback language
 - Strongly typed with TypedDict schema defined in `src/i18n/translator.py`
 - Translator class (`src/i18n/translator.py`) handles language loading and fallback
@@ -225,7 +227,7 @@ Runs in background to trigger:
 **Supported Languages:**
 
 - English, Dansk (Danish), Deutsch (German), Español (Spanish), Français (French)
-- Indonesian, Italiano (Italian), Nederlandse (Dutch), Polski (Polish), Português (Portuguese)
+- Magyar (Hungarian), Indonesian, Italiano (Italian), Nederlandse (Dutch), Polski (Polish), Português (Portuguese)
 - Română (Romanian), Türkçe (Turkish), Čeština (Czech)
 - Русский (Russian), Українська (Ukrainian), العربية (Arabic)
 - 日本語 (Japanese), 简体中文 (Simplified Chinese), 繁體中文 (Traditional Chinese)
@@ -271,7 +273,7 @@ login_text = _.t["login"]["status"]["logged_in"]  # Returns "Logged in"
 - **src/i18n/** - Internationalization package with TypedDict schema and Translator class
   - **translator.py** - Translator class with typed translation schema (Translation TypedDict)
   - **__init__.py** - Exports translation types and `_` (Translator instance)
-- **lang/** - Translation JSON files for 19 languages (English.json is the single source of truth)
+- **lang/** - Translation JSON files for 20 languages (English.json is the single source of truth)
 - **src/version.py** - Version string
 - **src/web/app.py** - FastAPI application with REST API and Socket.IO
 - **src/web/managers/cache.py** - ImageCache for campaign artwork caching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
-including README, contributor and release automation, and inventory-filter behavior.
+including README, contributor and release automation, inventory/watch-drop filtering,
+channel visibility, frontend asset versioning, and translation behavior.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,2 +1,3 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
-including README, contributor and release automation, and inventory-filter behavior.
+including README, contributor and release automation, inventory/watch-drop filtering,
+channel visibility, frontend asset versioning, and translation behavior.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Then open <http://localhost:8080>.
 
 Inventory filters combine **Active**, **Upcoming**, and **Expired** as alternatives.
 **Not Linked** narrows that status result, while fully claimed campaigns stay hidden
-until **Finished** is selected.
+until **Finished** is selected. Zero-minute subscription rewards are omitted from the
+Inventory and Wanted Drops Queue because they cannot be earned by watching. The channel
+list keeps the actively watched channel visible while game settings are changing.
 
 > [!NOTE]
 > Your Twitch account must be linked to the relevant game accounts. Review your
@@ -148,6 +150,7 @@ This project is a modern fork of
 - **French** — [@roobini-gamer](https://github.com/roobini-gamer) and
   [@Calvineries](https://github.com/Calvineries)
 - **German** — [@ThisIsCyreX](https://github.com/ThisIsCyreX)
+- **Hungarian** — [@centipederat](https://github.com/centipederat)
 - **Indonesian** — [@Eriza-Z](https://github.com/Eriza-Z)
 - **Italian** — [@casungo](https://github.com/casungo)
 - **Japanese** — [@ShimadaNanaki](https://github.com/ShimadaNanaki)

--- a/lang/Magyar.json
+++ b/lang/Magyar.json
@@ -1,0 +1,207 @@
+{
+    "language_name": "Magyar",
+    "english_name": "Hungarian",
+    "status": {
+        "terminated": "\nAlkalmazás leállítva.\nZárja be az ablakot a kilépéshez.",
+        "watching": "Nézés: {channel}",
+        "goes_online": "{channel} online lesz, váltás...",
+        "goes_offline": "{channel} offline lett, váltás...",
+        "claimed_drop": "Átvett jutalom: {drop}",
+        "no_channel": "Nincsenek elérhető csatornák a nézéshez. Várakozás online csatornára...",
+        "no_campaign": "Nincsenek aktív kampányok jutalmak bányászásához. Várakozás aktív kampányra..."
+    },
+    "login": {
+        "unexpected_content": "Váratlan tartalomtípus érkezett, általában átirányítás miatt. Szükséges bejelentkezni az internethez való hozzáféréshez?",
+        "error_code": "Bejelentkezési hiba kódja: {error_code}",
+        "incorrect_login_pass": "Hibás felhasználónév vagy jelszó.",
+        "incorrect_email_code": "Hibás email kód.",
+        "incorrect_twofa_code": "Hibás 2FA kód.",
+        "email_code_required": "Email kód szükséges. Ellenőrizze az emailt.",
+        "twofa_code_required": "2FA token szükséges.",
+        "status": {
+            "logged_in": "Bejelentkezve",
+            "logged_out": "Kijelentkezve",
+            "logging_in": "Bejelentkezés...",
+            "required": "Bejelentkezés szükséges",
+            "waiting_auth": "Várakozás az autentikációra..."
+        }
+    },
+    "error": {
+        "captcha": "A bejelentkezési kísérletet a CAPTCHA megtagadta.\nPróbálja újra 12+ óra múlva.",
+        "site_down": "A Twitch nem elérhető, újrapróbálkozás {seconds} másodperc múlva...",
+        "no_connection": "Nem lehet csatlakozni a Twitch-hez, újrapróbálkozás {seconds} másodperc múlva..."
+    },
+    "gui": {
+        "output": "Kimenet",
+        "status": {
+            "name": "Állapot",
+            "idle": "Tétlen",
+            "ready": "Kész",
+            "exiting": "Kilépés...",
+            "terminated": "Leállítva",
+            "cleanup": "Csatornák tisztítása...",
+            "gathering": "Csatornák gyűjtése...",
+            "switching": "Csatorna váltása...",
+            "fetching_inventory": "Készlet lekérése...",
+            "fetching_campaigns": "Kampányok lekérése...",
+            "adding_campaigns": "Kampányok hozzáadása a készlethez... {counter}"
+        },
+        "tabs": {
+            "main": "Kezdőlap",
+            "inventory": "Készlet",
+            "settings": "Beállítások",
+            "help": "Súgó"
+        },
+        "login": {
+            "name": "Bejelentkezési űrlap",
+            "labels": "Állapot:\nFelhasználói azonosító:",
+            "request": "Kérjük, jelentkezzen be a folytatáshoz.",
+            "username": "Felhasználónév",
+            "password": "Jelszó",
+            "twofa_code": "2FA kód (opcionális)",
+            "button": "Bejelentkezés",
+            "oauth_prompt": "Adja meg ezt a kódot itt:",
+            "oauth_activate": "Twitch Aktiválás",
+            "oauth_confirm": "Megadtam a kódot"
+        },
+        "websocket": {
+            "name": "Websocket állapot",
+            "websocket": "Websocket #{id}:",
+            "initializing": "Inicializálás...",
+            "connected": "Csatlakoztatva",
+            "disconnected": "Nincs kapcsolat",
+            "connecting": "Csatlakozás...",
+            "disconnecting": "Kapcsolat bontása...",
+            "reconnecting": "Újracsatlakozás..."
+        },
+        "progress": {
+            "name": "Kampány előrehaladás",
+            "drop": "Jutalom:",
+            "game": "Játék:",
+            "campaign": "Kampány:",
+            "remaining": "{time} hátravan",
+            "drop_progress": "Előrehaladás:",
+            "campaign_progress": "Előrehaladás:",
+            "no_drop": "Nincs aktív jutalom",
+            "return_to_auto": "Vissza automatikus módba",
+            "manual_mode_info": "Kézi mód: Bányászás"
+        },
+        "channels": {
+            "name": "Csatornák",
+            "online": "ONLINE  ✔",
+            "pending": "OFFLINE ⏳",
+            "offline": "OFFLINE ❌",
+            "no_channels": "Még nincs követett csatorna...",
+            "no_channels_for_games": "Nincs csatorna a kiválasztott játékokhoz...",
+            "channel_count": "csatorna",
+            "channel_count_plural": "csatornák",
+            "viewers": "néző"
+        },
+        "settings": {
+            "general": {
+                "name": "Általános",
+                "dark_mode": "Sötét mód"
+            },
+            "mining_benefits": "Bányászati előnyök",
+            "mining_benefits_help": "Válassza ki, mely típusú jutalmakat szeretné bányászni.",
+            "reload": "Kampányok újratöltése",
+            "reload_campaigns": "Kampányok újratöltése",
+            "games_to_watch": "Nézendő játékok",
+            "games_help": "Válassza ki a nézendő játékokat. A sorrend számít - húzással módosítható a prioritás (felül = legmagasabb).",
+            "search_games": "Játékok keresése...",
+            "add_game": "Játék hozzáadása",
+            "add_game_hint": " A játék kézi hozzáadásához kattintson a „Játék hozzáadása” gombra.",
+            "select_all": "Összes kijelölése",
+            "deselect_all": "Összes kijelölés törlése",
+            "selected_games": "Kiválasztott játékok (húzással módosítható)",
+            "available_games": "Elérhető játékok",
+            "no_games_selected": "Nincs kiválasztott játék. Jelölje ki a lenti listából.",
+            "no_games_match": "Nincs a keresésnek megfelelő játék.",
+            "all_games_selected": "Minden játék ki van jelölve, vagy nincs elérhető játék.",
+            "actions": "Műveletek",
+            "connection_quality": "Kapcsolat minősége:",
+            "minimum_refresh": "Minimális frissítési intervallum (perc):"
+        },
+        "help": {
+            "about": "A Twitch Drops Miner-ről",
+            "about_text": "Ez az alkalmazás automatikusan bányássza a időzített Twitch jutalmakat anélkül, hogy letöltené a stream adatokat.",
+            "how_to_use": "Használati útmutató",
+            "how_to_use_items": [
+                "Jelentkezzen be a Twitch fiókjával (OAuth eszközkód folyamat)",
+                "Fiókok összekapcsolása a <a href=\"https://www.twitch.tv/drops/campaigns\" target=\"_blank\">twitch.tv/drops/campaigns</a> oldalon",
+                "A miner automatikusan felfedezi a kampányokat és elkezdi a bányászást",
+                "Konfigurálja a prioritásos játékokat a beállításokban",
+                "Kövesse az előrehaladást a Kezdőlap és Készlet füleken"
+            ],
+            "features": "Funkciók",
+            "features_items": [
+                "Stream nélküli jutalmak bányászása - sávszélesség megtakarítás",
+                "Játék prioritási és kizárási listák",
+                "Akár 199 csatorna nyomon követése egyszerre",
+                "Automatikus csatornaváltás",
+                "Valós idejű előrehaladás követés"
+            ],
+            "important_notes": "Fontos tudnivalók",
+            "important_notes_items": [
+                "Ne nézzen streamet ugyanazzal a fiókkal a bányászás közben",
+                "Őrizze biztonságban a cookies.jar fájlt",
+                "A jutalmakhoz szükséges a játékfiókok összekapcsolása"
+            ],
+            "github_repo": "GitHub tároló"
+        },
+        "header": {
+            "title": "Twitch Drops Miner",
+            "language": "Nyelv:",
+            "initializing": "Inicializálás...",
+            "auto_mode": "AUTOMATIKUS",
+            "manual_mode": "KÉZI",
+            "connected": "Csatlakoztatva",
+            "disconnected": "Nincs kapcsolat"
+        },
+        "footer": {
+            "version": "Verzió:",
+            "loading": "Betöltés...",
+            "update_available": "Frissítés elérhető:"
+        },
+        "badges": {
+            "manual": {
+                "title": "Kézi mód aktív - konkrét játék nézése"
+            },
+            "auto": {
+                "title": "Automatikus mód - játék prioritás követése"
+            },
+            "proxy": {
+                "title": "Proxy kapcsolat aktív"
+            }
+        },
+        "wanted": {
+            "name": "Kívánt jutalmak sorban",
+            "none": "Nincsenek kívánt jutalmak sorban..."
+        },
+        "inventory": {
+            "no_campaigns": "Még nincs betöltött kampány...",
+            "status": {
+                "active": "Aktív ✔",
+                "upcoming": "Hamarosan ⏳",
+                "expired": "Lejárt ❌",
+                "claimed": "Átvett ✔"
+            },
+            "starts": "Kezdés: {time}",
+            "ends": "Befejezés: {time}",
+            "claimed_drops": "átvett",
+            "filters": {
+                "active": "Aktív",
+                "not_linked": "Nincs összekapcsolva",
+                "upcoming": "Hamarosan",
+                "expired": "Lejárt",
+                "finished": "Befejezett",
+                "item": "Tárgy",
+                "badge": "Jelvény",
+                "emote": "Emotikon",
+                "other": "Egyéb",
+                "clear": "Szűrők törlése",
+                "search_placeholder": "Írjon a játékok kereséséhez..."
+            }
+        }
+    }
+}

--- a/src/models/campaign.py
+++ b/src/models/campaign.py
@@ -93,7 +93,7 @@ class DropsCampaign:
 
     @property
     def finished(self) -> bool:
-        return all(d.is_claimed or d.required_minutes <= 0 for d in self.drops)
+        return all(d.is_claimed or not d.is_watch_drop for d in self.drops)
 
     @property
     def claimed_drops(self) -> int:

--- a/src/models/drop.py
+++ b/src/models/drop.py
@@ -228,6 +228,11 @@ class TimedDrop(BaseDrop):
         return self.real_current_minutes + self.extra_current_minutes
 
     @property
+    def is_watch_drop(self) -> bool:
+        """Return whether this drop can be earned by watching a stream."""
+        return self.required_minutes > 0
+
+    @property
     def remaining_minutes(self) -> int:
         return self.required_minutes - self.current_minutes
 
@@ -253,7 +258,7 @@ class TimedDrop(BaseDrop):
 
     @property
     def progress(self) -> float:
-        if self.current_minutes <= 0 or self.required_minutes <= 0:
+        if self.current_minutes <= 0 or not self.is_watch_drop:
             return 0.0
         elif self.current_minutes >= self.required_minutes:
             return 1.0
@@ -264,14 +269,14 @@ class TimedDrop(BaseDrop):
         import math
 
         now = datetime.now(timezone.utc)
-        if self.required_minutes > 0 and self.total_remaining_minutes > 0 and now < self.ends_at:
+        if self.is_watch_drop and self.total_remaining_minutes > 0 and now < self.ends_at:
             return ((self.ends_at - now).total_seconds() / 60) / self.total_remaining_minutes
         return math.inf
 
     def _base_earn_conditions(self) -> bool:
         return (
             super()._base_earn_conditions()
-            and self.required_minutes > 0
+            and self.is_watch_drop
             # NOTE: This may be a bad idea, as it invalidates the can_earn status
             # and provides no way to recover from this state until the next reload.
             and self.extra_current_minutes < MAX_EXTRA_MINUTES

--- a/src/services/stream_selector.py
+++ b/src/services/stream_selector.py
@@ -36,7 +36,7 @@ class StreamSelector:
 
                 wanted_drops = []
                 for drop in campaign.drops:
-                    if drop.is_claimed:
+                    if not drop.is_watch_drop or drop.is_claimed:
                         continue
 
                     filtered_benefits = drop.get_wanted_unclaimed_benefits(mining_benefits)

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import socketio
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -98,7 +98,8 @@ async def serve_index():
         f"Looking for web files: __file__={__file__}, web_dir={web_dir}, index_file={index_file}, exists={index_file.exists()}"
     )
     if index_file.exists():
-        return FileResponse(index_file)
+        content = index_file.read_text(encoding="utf-8").replace("__APP_VERSION__", __version__)
+        return HTMLResponse(content=content, headers={"Cache-Control": "no-cache"})
     return HTMLResponse(
         content=f"<h1>Twitch Drops Miner</h1><p>Web interface files not found. Please check installation.</p><p>Debug: Looking for {index_file}</p>",
         status_code=500,
@@ -207,9 +208,9 @@ async def update_settings(settings: SettingsUpdate):
     if not gui_manager:
         raise HTTPException(status_code=503, detail="GUI not initialized")
 
-    settings_dict = settings.dict(exclude_unset=True)
-    gui_manager.settings.update_settings(settings_dict)
-    return {"success": True, "settings": gui_manager.settings.get_settings()}
+    settings_dict = settings.model_dump(exclude_unset=True)
+    updated_settings = gui_manager.settings.update_settings(settings_dict)
+    return {"success": True, "settings": updated_settings}
 
 
 @app.post("/api/settings/verify-proxy")

--- a/src/web/managers/inventory.py
+++ b/src/web/managers/inventory.py
@@ -19,8 +19,8 @@ logger = logging.getLogger("TwitchDrops")
 class InventoryManager:
     """Manages drop campaign inventory display in the web interface.
 
-    Tracks all active, upcoming, and expired campaigns with their drops,
-    broadcasting real-time updates as drops are mined and claimed.
+    Tracks active, upcoming, and expired campaigns that contain watch drops,
+    broadcasting real-time updates as those drops are mined and claimed.
     """
 
     def __init__(self, broadcaster: WebSocketBroadcaster, cache: ImageCache):
@@ -31,10 +31,11 @@ class InventoryManager:
 
     @staticmethod
     def _campaign_progress(campaign: DropsCampaign) -> dict[str, int]:
-        """Return the live drop counts used by inventory filters."""
+        """Return live counts for the watch drops visible in inventory."""
+        watch_drops = [drop for drop in campaign.drops if drop.is_watch_drop]
         return {
-            "claimed_drops": campaign.claimed_drops,
-            "total_drops": campaign.total_drops,
+            "claimed_drops": sum(drop.is_claimed for drop in watch_drops),
+            "total_drops": len(watch_drops),
         }
 
     def clear(self):
@@ -50,8 +51,12 @@ class InventoryManager:
         """
         # Get campaign image from cache
 
+        watch_drops = [drop for drop in campaign.drops if drop.is_watch_drop]
+        if not watch_drops:
+            return
+
         drops_data = []
-        for drop in campaign.drops:
+        for drop in watch_drops:
             # Collect full benefit data (filter out benefits without images)
             benefits_data = [
                 {
@@ -108,11 +113,10 @@ class InventoryManager:
         """
         campaign_id = drop.campaign.id
         if campaign_id in self._campaigns:
-            campaign_progress = self._campaign_progress(drop.campaign)
-            self._campaigns[campaign_id].update(campaign_progress)
+            campaign_data = self._campaigns[campaign_id]
 
             # Find and update the drop in the campaign
-            for drop_data in self._campaigns[campaign_id]["drops"]:
+            for drop_data in campaign_data["drops"]:
                 if drop_data["id"] == drop.id:
                     drop_data.update(
                         {
@@ -123,6 +127,13 @@ class InventoryManager:
                             "can_claim": drop.can_claim,
                         }
                     )
+                    campaign_progress = {
+                        "claimed_drops": sum(
+                            item["is_claimed"] for item in campaign_data["drops"]
+                        ),
+                        "total_drops": len(campaign_data["drops"]),
+                    }
+                    campaign_data.update(campaign_progress)
                     asyncio.create_task(
                         self._broadcaster.emit(
                             "drop_update",

--- a/src/web/managers/settings.py
+++ b/src/web/managers/settings.py
@@ -43,13 +43,22 @@ class SettingsManager:
         self._on_change = on_change
         self._available_games: list[str] = []
 
-    def get_settings(self) -> dict[str, Any]:
+    def get_settings(self, legacy_show_not_linked: bool | None = None) -> dict[str, Any]:
         """Get current settings for display.
+
+        Args:
+            legacy_show_not_linked: Request-scoped value to echo to a legacy
+                frontend. It is never persisted or mapped to the current
+                ``show_only_not_linked`` restriction.
 
         Returns:
             Dictionary containing all user-configurable settings
         """
         settings = vars(self._settings).copy()
+        if legacy_show_not_linked is not None:
+            inventory_filters = copy.deepcopy(dict(self._settings.inventory_filters))
+            inventory_filters["show_not_linked"] = legacy_show_not_linked
+            settings["inventory_filters"] = inventory_filters
         return settings
 
     def get_languages(self) -> dict[str, Any]:
@@ -67,7 +76,7 @@ class SettingsManager:
         """Log setting change to both console and system logger."""
         self._console.print(message)
 
-    def update_settings(self, settings_data: dict[str, Any]):
+    def update_settings(self, settings_data: dict[str, Any]) -> dict[str, Any]:
         """Update settings from user input.
 
         Args:
@@ -99,7 +108,11 @@ class SettingsManager:
             settings_data.get("minimum_refresh_interval_minutes"),
         )
         inventory_filters = settings_data.get("inventory_filters")
+        legacy_show_not_linked = None
         if inventory_filters is not None:
+            legacy_value = inventory_filters.get("show_not_linked")
+            if isinstance(legacy_value, bool):
+                legacy_show_not_linked = legacy_value
             inventory_filters = self._normalize_inventory_filters(inventory_filters)
         should_trigger_update |= self.check_and_update_setting("inventory_filters", inventory_filters)
         should_trigger_update |= self.check_and_update_setting(
@@ -110,10 +123,13 @@ class SettingsManager:
         )
 
         self._settings.save()
-        asyncio.create_task(self._broadcaster.emit("settings_updated", self.get_settings()))
+        response_settings = self.get_settings(legacy_show_not_linked)
+        asyncio.create_task(self._broadcaster.emit("settings_updated", response_settings))
 
         if should_trigger_update and self._on_change:
             self._on_change()
+
+        return response_settings
 
     def _normalize_inventory_filters(self, updates: dict[str, Any]) -> dict[str, Any]:
         """Merge partial filter updates and discard legacy or unknown keys."""

--- a/tests/test_channel_rendering.py
+++ b/tests/test_channel_rendering.py
@@ -1,0 +1,84 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+APP_JS = Path(__file__).resolve().parents[1] / "web" / "static" / "app.js"
+NODE = shutil.which("node")
+
+
+def _extract_javascript_function(source: str, name: str) -> str:
+    signature = f"function {name}("
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+
+    for index in range(brace_start, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+
+    raise AssertionError(f"Could not find the end of {name}()")
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for frontend tests")
+def test_watching_channel_remains_visible_outside_game_filter():
+    app_source = APP_JS.read_text(encoding="utf-8")
+    function_source = _extract_javascript_function(
+        app_source, "channelMatchesGameFilter"
+    )
+    cases = [
+        {
+            "channel": {"game": "Game A", "watching": False},
+            "games": ["Game A"],
+            "expected": True,
+        },
+        {
+            "channel": {"game": "Game B", "watching": False},
+            "games": ["Game A"],
+            "expected": False,
+        },
+        {
+            "channel": {"game": "Game B", "watching": True},
+            "games": ["Game A"],
+            "expected": True,
+        },
+        {
+            "channel": {"game": None, "watching": True},
+            "games": ["Game A"],
+            "expected": True,
+        },
+        {
+            "channel": {"game": "Game B", "watching": False},
+            "games": [],
+            "expected": True,
+        },
+    ]
+
+    script = f"""
+{function_source}
+const cases = {json.dumps(cases)};
+const results = cases.map(testCase => channelMatchesGameFilter(
+    testCase.channel,
+    new Set(testCase.games),
+));
+process.stdout.write(JSON.stringify(results));
+    """
+    completed = subprocess.run(
+        [NODE, "-"],
+        check=True,
+        capture_output=True,
+        input=script,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout) == [case["expected"] for case in cases]
+    assert "channelMatchesGameFilter(channel, gamesToWatchSet)" in _extract_javascript_function(
+        app_source, "renderChannels"
+    )

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -1,10 +1,14 @@
 import asyncio
+import importlib
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.config.settings import Settings, default_settings
 from src.web.app import SettingsUpdate
 from src.web.managers.settings import SettingsManager
+
+
+web_app = importlib.import_module("src.web.app")
 
 
 class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
@@ -18,7 +22,27 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(model.inventory_filters, update_data["inventory_filters"])
         self.assertEqual(model.mining_benefits, update_data["mining_benefits"])
 
-    async def test_inventory_filter_updates_merge_and_discard_legacy_key(self):
+    async def test_settings_endpoint_returns_request_scoped_compatibility_response(self):
+        expected = {
+            "inventory_filters": {
+                "show_only_not_linked": False,
+                "show_not_linked": True,
+            }
+        }
+        mock_gui = MagicMock()
+        mock_gui.settings.update_settings.return_value = expected
+
+        with patch.object(web_app, "gui_manager", mock_gui):
+            response = await web_app.update_settings(
+                SettingsUpdate(inventory_filters={"show_not_linked": True})
+            )
+
+        assert response == {"success": True, "settings": expected}
+        mock_gui.settings.update_settings.assert_called_once_with(
+            {"inventory_filters": {"show_not_linked": True}}
+        )
+
+    async def test_legacy_filter_request_is_echoed_without_changing_current_semantics(self):
         mock_broadcaster = AsyncMock()
         mock_settings = MagicMock(spec=Settings)
         mock_settings.inventory_filters = {
@@ -35,7 +59,7 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         }
         manager = SettingsManager(mock_broadcaster, mock_settings, MagicMock())
 
-        manager.update_settings(
+        response_settings = manager.update_settings(
             {"inventory_filters": {"show_active": True, "show_not_linked": True}}
         )
         await asyncio.sleep(0)
@@ -45,7 +69,32 @@ class TestSettingsAPI(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(filters["game_name_search"], ["Game A"])
         self.assertFalse(filters["show_only_not_linked"])
         self.assertNotIn("show_not_linked", filters)
+        self.assertTrue(response_settings["inventory_filters"]["show_not_linked"])
+        self.assertFalse(response_settings["inventory_filters"]["show_only_not_linked"])
+        self.assertNotIn("show_not_linked", manager.get_settings()["inventory_filters"])
+        mock_broadcaster.emit.assert_awaited_once_with(
+            "settings_updated", response_settings
+        )
         mock_settings.save.assert_called_once()
+
+    async def test_persisted_legacy_filter_is_removed_without_becoming_only_not_linked(self):
+        mock_broadcaster = AsyncMock()
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.inventory_filters = {
+            "show_not_linked": True,
+        }
+        manager = SettingsManager(mock_broadcaster, mock_settings, MagicMock())
+
+        response_settings = manager.update_settings(
+            {"inventory_filters": {"show_active": True}}
+        )
+        await asyncio.sleep(0)
+
+        filters = mock_settings.inventory_filters
+        self.assertTrue(filters["show_active"])
+        self.assertFalse(filters["show_only_not_linked"])
+        self.assertNotIn("show_not_linked", filters)
+        self.assertNotIn("show_not_linked", response_settings["inventory_filters"])
 
     async def test_settings_manager_networking(self):
         # Mock dependencies

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,7 +1,34 @@
 import json
+from string import Formatter
+from typing import Any
 
 from src.config import LANG_PATH
 from src.i18n.translator import GUISettings
+
+
+def _assert_translation_shape(reference: Any, translation: Any, path: str = "root") -> None:
+    assert type(translation) is type(reference), path
+
+    if isinstance(reference, dict):
+        assert set(translation) == set(reference), path
+        for key, value in reference.items():
+            _assert_translation_shape(value, translation[key], f"{path}.{key}")
+    elif isinstance(reference, list):
+        assert len(translation) == len(reference), path
+        for index, value in enumerate(reference):
+            _assert_translation_shape(value, translation[index], f"{path}[{index}]")
+    elif isinstance(reference, str):
+        reference_fields = sorted(
+            field_name
+            for _, field_name, _, _ in Formatter().parse(reference)
+            if field_name is not None
+        )
+        translation_fields = sorted(
+            field_name
+            for _, field_name, _, _ in Formatter().parse(translation)
+            if field_name is not None
+        )
+        assert translation_fields == reference_fields, path
 
 
 def test_all_language_settings_include_gui_settings_schema_keys():
@@ -20,3 +47,12 @@ def test_all_language_settings_include_gui_settings_schema_keys():
 
     assert sorted(set(english_settings) - required_settings_keys) == []
     assert missing_by_language == {}
+
+
+def test_hungarian_translation_matches_english_schema_and_placeholders():
+    english = json.loads((LANG_PATH / "English.json").read_text(encoding="utf-8"))
+    hungarian = json.loads((LANG_PATH / "Magyar.json").read_text(encoding="utf-8"))
+
+    assert hungarian["language_name"] == "Magyar"
+    assert hungarian["english_name"] == "Hungarian"
+    _assert_translation_shape(english, hungarian)

--- a/tests/test_watch_drop_filtering.py
+++ b/tests/test_watch_drop_filtering.py
@@ -1,0 +1,101 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.campaign import DropsCampaign
+from src.services.stream_selector import StreamSelector
+from src.web.managers.inventory import InventoryManager
+
+
+def _drop(drop_id: str, name: str, required_minutes: int) -> dict:
+    return {
+        "id": drop_id,
+        "name": name,
+        "benefitEdges": [
+            {
+                "benefit": {
+                    "id": f"benefit-{drop_id}",
+                    "name": f"Reward {name}",
+                    "distributionType": "DIRECT_ENTITLEMENT",
+                    "imageAssetURL": f"https://example.test/{drop_id}.png",
+                }
+            }
+        ],
+        "startAt": "2026-01-01T00:00:00Z",
+        "endAt": "2099-01-01T00:00:00Z",
+        "preconditionDrops": [],
+        "requiredMinutesWatched": required_minutes,
+    }
+
+
+def _campaign(campaign_id: str, drops: list[dict]) -> DropsCampaign:
+    return DropsCampaign(
+        MagicMock(),
+        {
+            "id": campaign_id,
+            "name": f"Campaign {campaign_id}",
+            "game": {
+                "id": "1",
+                "name": "Test Game",
+                "displayName": "Test Game",
+                "boxArtURL": "https://example.test/game-{width}x{height}.jpg",
+            },
+            "self": {"isAccountConnected": True},
+            "accountLinkURL": "https://example.test/link",
+            "startAt": "2026-01-01T00:00:00Z",
+            "endAt": "2099-01-01T00:00:00Z",
+            "status": "ACTIVE",
+            "allow": {"channels": [], "isEnabled": True},
+            "timeBasedDrops": drops,
+        },
+        {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_hides_subscription_drops_and_sub_only_campaigns():
+    broadcaster = MagicMock()
+    broadcaster.emit = AsyncMock()
+    manager = InventoryManager(broadcaster, MagicMock())
+    sub_only = _campaign("sub-only", [_drop("sub", "Subscribe", 0)])
+    mixed = _campaign(
+        "mixed",
+        [
+            _drop("sub", "Subscribe", 0),
+            _drop("watch", "Watch", 30),
+        ],
+    )
+
+    await manager.add_campaign(sub_only)
+    await manager.add_campaign(mixed)
+
+    assert [campaign["id"] for campaign in manager.get_campaigns()] == ["mixed"]
+    mixed_data = manager.get_campaigns()[0]
+    assert [drop["id"] for drop in mixed_data["drops"]] == ["watch"]
+    assert mixed_data["claimed_drops"] == 0
+    assert mixed_data["total_drops"] == 1
+    broadcaster.emit.assert_awaited_once_with("campaign_add", mixed_data)
+
+
+def test_wanted_queue_hides_subscription_drops_and_sub_only_campaigns():
+    sub_only = _campaign("sub-only", [_drop("sub", "Subscribe", 0)])
+    mixed = _campaign(
+        "mixed",
+        [
+            _drop("sub", "Subscribe", 0),
+            _drop("watch", "Watch", 30),
+        ],
+    )
+    settings = SimpleNamespace(
+        games_to_watch=["Test Game"],
+        mining_benefits={"DIRECT_ENTITLEMENT": True},
+    )
+
+    result = StreamSelector().get_wanted_game_tree(settings, [sub_only, mixed])
+
+    assert len(result) == 1
+    assert [campaign["id"] for campaign in result[0]["campaigns"]] == ["mixed"]
+    assert [drop["name"] for drop in result[0]["campaigns"][0]["drops"]] == ["Watch"]
+    assert sub_only.can_earn_within(datetime.now(timezone.utc)) is False

--- a/tests/test_web_asset_versioning.py
+++ b/tests/test_web_asset_versioning.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from fastapi.responses import HTMLResponse
+
+from src.version import __version__
+from src.web.app import serve_index
+
+
+def test_index_revalidates_and_versions_local_assets():
+    response = asyncio.run(serve_index())
+
+    assert isinstance(response, HTMLResponse)
+    assert response.headers["cache-control"] == "no-cache"
+
+    body = response.body.decode()
+    assert f'/static/styles.css?v={__version__}' in body
+    assert f'/static/app.js?v={__version__}' in body
+    assert "__APP_VERSION__" not in body

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Twitch Drops Miner</title>
     <link rel="icon" type="image/png" href="/static/favicon.png">
-    <link rel="stylesheet" href="/static/styles.css">
+    <link rel="stylesheet" href="/static/styles.css?v=__APP_VERSION__">
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
 </head>
 
@@ -328,7 +328,7 @@
         </footer>
     </div>
 
-    <script src="/static/app.js"></script>
+    <script src="/static/app.js?v=__APP_VERSION__"></script>
 </body>
 
 </html>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -345,6 +345,12 @@ function clearWatchingChannel() {
     renderChannels();
 }
 
+function channelMatchesGameFilter(channel, gamesToWatchSet) {
+    return channel.watching ||
+        gamesToWatchSet.size === 0 ||
+        Boolean(channel.game && gamesToWatchSet.has(channel.game));
+}
+
 function renderChannels() {
     const container = document.getElementById('channels-list');
     container.innerHTML = '';
@@ -363,13 +369,11 @@ function renderChannels() {
     const gamesToWatch = state.settings.games_to_watch || [];
     const gamesToWatchSet = new Set(gamesToWatch);
 
-    // Filter channels to only include those playing games in the watch list
-    const filteredChannels = channels.filter(channel => {
-        const gameName = channel.game;
-        // Include channels if: they have a game AND it's in the watch list
-        // OR if the watch list is empty (show all)
-        return gamesToWatch.length === 0 || (gameName && gamesToWatchSet.has(gameName));
-    });
+    // The active channel remains visible while a settings update changes the
+    // game filter; all other channels must match the configured watch list.
+    const filteredChannels = channels.filter(
+        channel => channelMatchesGameFilter(channel, gamesToWatchSet)
+    );
 
     if (filteredChannels.length === 0) {
         const emptyMsg = t.gui?.channels?.no_channels_for_games || 'No channels found for selected games...';


### PR DESCRIPTION
## Summary

- preserve legacy inventory-filter compatibility for cached clients and version frontend assets
- keep the actively watched channel visible when filtering configured games
- hide zero-minute subscription drops from inventory and wanted queues while retaining valid mixed-campaign drops
- add and validate the Hungarian translation

## Validation

- `python -W error::RuntimeWarning -m pytest tests/ -q` — 54 passed
- Ruff and Mypy
- Node syntax check and Actionlint
- `uv lock --check` and `git diff --check`
- AMD64 Docker build

Closes #81
Closes #82
Closes #37
Closes #67