### PR TITLE
Fix PR #84 follow-up review findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,10 @@ lang/                # Translation JSON files (20 languages)
 - Socket.IO server for real-time bi-directional communication
 - Serves static web frontend from `web/` directory
 - Integrates with WebGUIManager via `set_managers()`
+- `serve_index()` replaces the `__APP_VERSION__` placeholder in local CSS/JavaScript URLs
+  with the application version and serves `/` with `Cache-Control: no-cache`
+- Any `app.js` or `styles.css` change requires an application version bump through the release
+  workflow before deployment so existing clients receive a new asset cache key
 
 **src/websocket/pool.py** - WebSocket management:
 
@@ -336,7 +340,8 @@ source env/bin/activate && python -m pytest tests/
 
 The suite covers settings and proxy behavior, inventory-filter behavior, API filtering,
 GraphQL watch events, batched channel discovery, translation consistency, frontend DOM
-safety, and contributor README automation. Inventory-filter behavior tests use Node.js;
+safety, case-insensitive channel filtering, watch-drop count semantics, and contributor
+README automation. Frontend behavior tests share their JavaScript extraction helper and use Node.js;
 the validation workflow provisions Node 24 before running pytest. It also runs the release
 script contract tests under `.github/scripts/test/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
 including README, contributor and release automation, inventory/watch-drop filtering,
-channel visibility, frontend asset versioning, and translation behavior.
+case-insensitive channel visibility, watch-drop count semantics, frontend asset versioning,
+and translation behavior.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,4 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
 including README, contributor and release automation, inventory/watch-drop filtering,
-channel visibility, frontend asset versioning, and translation behavior.
+case-insensitive channel visibility, watch-drop count semantics, frontend asset versioning,
+and translation behavior.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Inventory filters combine **Active**, **Upcoming**, and **Expired** as alternati
 **Not Linked** narrows that status result, while fully claimed campaigns stay hidden
 until **Finished** is selected. Zero-minute subscription rewards are omitted from the
 Inventory and Wanted Drops Queue because they cannot be earned by watching. The channel
-list keeps the actively watched channel visible while game settings are changing.
+list matches game names case-insensitively and keeps the actively watched channel visible
+while game settings are changing. Campaign totals and claim messages count only rewards
+that can be earned by watching.
 
 > [!NOTE]
 > Your Twitch account must be linked to the relevant game accounts. Review your

--- a/lang/Magyar.json
+++ b/lang/Magyar.json
@@ -124,7 +124,7 @@
         },
         "help": {
             "about": "A Twitch Drops Miner-ről",
-            "about_text": "Ez az alkalmazás automatikusan bányássza a időzített Twitch jutalmakat anélkül, hogy letöltené a stream adatokat.",
+            "about_text": "Ez az alkalmazás automatikusan bányássza az időzített Twitch jutalmakat anélkül, hogy letöltené a stream adatokat.",
             "how_to_use": "Használati útmutató",
             "how_to_use_items": [
                 "Jelentkezzen be a Twitch fiókjával (OAuth eszközkód folyamat)",

--- a/src/models/campaign.py
+++ b/src/models/campaign.py
@@ -56,6 +56,11 @@ class DropsCampaign:
     def drops(self) -> abc.Iterable[TimedDrop]:
         return self.timed_drops.values()
 
+    @cached_property
+    def watch_drops(self) -> tuple[TimedDrop, ...]:
+        """Return drops that can be earned by watching a stream."""
+        return tuple(drop for drop in self.drops if drop.is_watch_drop)
+
     @property
     def time_triggers(self) -> set[datetime]:
         return set(
@@ -79,7 +84,7 @@ class DropsCampaign:
 
     @property
     def total_drops(self) -> int:
-        return len(self.timed_drops)
+        return len(self.watch_drops)
 
     @property
     def eligible(self) -> bool:
@@ -93,36 +98,37 @@ class DropsCampaign:
 
     @property
     def finished(self) -> bool:
-        return all(d.is_claimed or not d.is_watch_drop for d in self.drops)
+        return all(drop.is_claimed for drop in self.watch_drops)
 
     @property
     def claimed_drops(self) -> int:
-        return sum(d.is_claimed for d in self.drops)
+        return sum(drop.is_claimed for drop in self.watch_drops)
 
     @property
     def remaining_drops(self) -> int:
-        return sum(not d.is_claimed for d in self.drops)
+        return sum(not drop.is_claimed for drop in self.watch_drops)
 
     @property
     def required_minutes(self) -> int:
-        return max(d.total_required_minutes for d in self.drops)
+        return max((drop.total_required_minutes for drop in self.watch_drops), default=0)
 
     @property
     def remaining_minutes(self) -> int:
-        return max(d.total_remaining_minutes for d in self.drops)
+        return max((drop.total_remaining_minutes for drop in self.watch_drops), default=0)
 
     @property
     def progress(self) -> float:
-        return sum(d.progress for d in self.drops) / self.total_drops
+        watch_drops = self.watch_drops
+        return sum(drop.progress for drop in watch_drops) / len(watch_drops) if watch_drops else 0.0
 
     @property
     def availability(self) -> float:
-        return min(d.availability for d in self.drops)
+        return min((drop.availability for drop in self.watch_drops), default=float("inf"))
 
     @property
     def first_drop(self) -> TimedDrop | None:
         drops: list[TimedDrop] = sorted(
-            (drop for drop in self.drops if drop.can_earn()),
+            (drop for drop in self.watch_drops if drop.can_earn()),
             key=lambda d: d.remaining_minutes,
         )
         return drops[0] if drops else None

--- a/src/web/managers/inventory.py
+++ b/src/web/managers/inventory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 
@@ -30,12 +31,12 @@ class InventoryManager:
         self._batch_mode: bool = False
 
     @staticmethod
-    def _campaign_progress(campaign: DropsCampaign) -> dict[str, int]:
-        """Return live counts for the watch drops visible in inventory."""
-        watch_drops = [drop for drop in campaign.drops if drop.is_watch_drop]
+    def _campaign_progress(drops: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+        """Return live counts for serialized drops visible in inventory."""
+        visible_drops = list(drops)
         return {
-            "claimed_drops": sum(drop.is_claimed for drop in watch_drops),
-            "total_drops": len(watch_drops),
+            "claimed_drops": sum(bool(drop["is_claimed"]) for drop in visible_drops),
+            "total_drops": len(visible_drops),
         }
 
     def clear(self):
@@ -95,7 +96,7 @@ class InventoryManager:
             "active": campaign.active,
             "upcoming": campaign.upcoming,
             "expired": campaign.expired,
-            **self._campaign_progress(campaign),
+            **self._campaign_progress(drops_data),
             "drops": drops_data,
         }
 
@@ -127,12 +128,7 @@ class InventoryManager:
                             "can_claim": drop.can_claim,
                         }
                     )
-                    campaign_progress = {
-                        "claimed_drops": sum(
-                            item["is_claimed"] for item in campaign_data["drops"]
-                        ),
-                        "total_drops": len(campaign_data["drops"]),
-                    }
+                    campaign_progress = self._campaign_progress(campaign_data["drops"])
                     campaign_data.update(campaign_progress)
                     asyncio.create_task(
                         self._broadcaster.emit(

--- a/src/web/managers/settings.py
+++ b/src/web/managers/settings.py
@@ -47,14 +47,17 @@ class SettingsManager:
         """Get current settings for display.
 
         Args:
-            legacy_show_not_linked: Request-scoped value to echo to a legacy
-                frontend. It is never persisted or mapped to the current
-                ``show_only_not_linked`` restriction.
+            legacy_show_not_linked: Request-scoped value echoed only in the
+                immediate settings POST response for a legacy frontend. It is
+                never persisted, mapped to ``show_only_not_linked``, or returned
+                by a later GET/page reload.
 
         Returns:
             Dictionary containing all user-configurable settings
         """
         settings = vars(self._settings).copy()
+        # TODO(remove in 1.3.x): Retain this POST-only echo long enough for stale
+        # pre-versioned frontends to age out; it never survives a page reload.
         if legacy_show_not_linked is not None:
             inventory_filters = copy.deepcopy(dict(self._settings.inventory_filters))
             inventory_filters["show_not_linked"] = legacy_show_not_linked

--- a/tests/javascript_helpers.py
+++ b/tests/javascript_helpers.py
@@ -1,0 +1,26 @@
+"""Shared helpers for executing isolated frontend functions in Node.js tests."""
+
+import shutil
+from pathlib import Path
+
+
+APP_JS = Path(__file__).resolve().parents[1] / "web" / "static" / "app.js"
+NODE = shutil.which("node")
+
+
+def extract_javascript_function(source: str, name: str) -> str:
+    """Extract a top-level JavaScript function declaration from source text."""
+    signature = f"function {name}("
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+
+    for index in range(brace_start, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+
+    raise AssertionError(f"Could not find the end of {name}()")

--- a/tests/test_channel_rendering.py
+++ b/tests/test_channel_rendering.py
@@ -1,36 +1,15 @@
 import json
-import shutil
 import subprocess
-from pathlib import Path
 
 import pytest
 
-
-APP_JS = Path(__file__).resolve().parents[1] / "web" / "static" / "app.js"
-NODE = shutil.which("node")
-
-
-def _extract_javascript_function(source: str, name: str) -> str:
-    signature = f"function {name}("
-    start = source.index(signature)
-    brace_start = source.index("{", start)
-    depth = 0
-
-    for index in range(brace_start, len(source)):
-        if source[index] == "{":
-            depth += 1
-        elif source[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return source[start : index + 1]
-
-    raise AssertionError(f"Could not find the end of {name}()")
+from tests.javascript_helpers import APP_JS, NODE, extract_javascript_function
 
 
 @pytest.mark.skipif(NODE is None, reason="Node.js is required for frontend tests")
 def test_watching_channel_remains_visible_outside_game_filter():
     app_source = APP_JS.read_text(encoding="utf-8")
-    function_source = _extract_javascript_function(
+    function_source = extract_javascript_function(
         app_source, "channelMatchesGameFilter"
     )
     cases = [
@@ -59,6 +38,11 @@ def test_watching_channel_remains_visible_outside_game_filter():
             "games": [],
             "expected": True,
         },
+        {
+            "channel": {"game": "Rust", "watching": False},
+            "games": ["rust"],
+            "expected": True,
+        },
     ]
 
     script = f"""
@@ -66,7 +50,7 @@ def test_watching_channel_remains_visible_outside_game_filter():
 const cases = {json.dumps(cases)};
 const results = cases.map(testCase => channelMatchesGameFilter(
     testCase.channel,
-    new Set(testCase.games),
+    new Set(testCase.games.map(game => game.toLowerCase())),
 ));
 process.stdout.write(JSON.stringify(results));
     """
@@ -79,6 +63,6 @@ process.stdout.write(JSON.stringify(results));
     )
 
     assert json.loads(completed.stdout) == [case["expected"] for case in cases]
-    assert "channelMatchesGameFilter(channel, gamesToWatchSet)" in _extract_javascript_function(
-        app_source, "renderChannels"
-    )
+    render_source = extract_javascript_function(app_source, "renderChannels")
+    assert "new Set(gamesToWatch.map(g => g.toLowerCase()))" in render_source
+    assert "channelMatchesGameFilter(channel, gamesToWatchSet)" in render_source

--- a/tests/test_inventory_filters.py
+++ b/tests/test_inventory_filters.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-import shutil
 import subprocess
 import unittest
 from pathlib import Path
@@ -13,29 +12,11 @@ import pytest
 from src.config.settings import default_settings
 from src.utils import merge_json
 from src.web.managers.inventory import InventoryManager
+from tests.javascript_helpers import APP_JS, NODE, extract_javascript_function
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-APP_JS = PROJECT_ROOT / "web" / "static" / "app.js"
 INDEX_HTML = PROJECT_ROOT / "web" / "index.html"
-NODE = shutil.which("node")
-
-
-def _extract_javascript_function(source: str, name: str) -> str:
-    signature = f"function {name}("
-    start = source.index(signature)
-    brace_start = source.index("{", start)
-    depth = 0
-
-    for index in range(brace_start, len(source)):
-        if source[index] == "{":
-            depth += 1
-        elif source[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return source[start : index + 1]
-
-    raise AssertionError(f"Could not find the end of {name}()")
 
 
 def test_inventory_filter_defaults_hide_finished_without_restricting_link_state():
@@ -110,7 +91,7 @@ class TestInventoryDropUpdates(unittest.IsolatedAsyncioTestCase):
 
 @pytest.mark.skipif(NODE is None, reason="Node.js is required for frontend tests")
 def test_campaign_filter_behavior_matrix():
-    function_source = _extract_javascript_function(
+    function_source = extract_javascript_function(
         APP_JS.read_text(encoding="utf-8"), "campaignMatchesFilters"
     )
     base_filters = {

--- a/tests/test_watch_drop_filtering.py
+++ b/tests/test_watch_drop_filtering.py
@@ -71,12 +71,44 @@ async def test_inventory_hides_subscription_drops_and_sub_only_campaigns():
     await manager.add_campaign(sub_only)
     await manager.add_campaign(mixed)
 
+    assert sub_only.total_drops == 0
+    assert sub_only.claimed_drops == 0
+    assert sub_only.remaining_drops == 0
+    assert sub_only.required_minutes == 0
+    assert sub_only.remaining_minutes == 0
+    assert sub_only.progress == 0.0
+    assert sub_only.availability == float("inf")
+    assert sub_only.finished is True
     assert [campaign["id"] for campaign in manager.get_campaigns()] == ["mixed"]
     mixed_data = manager.get_campaigns()[0]
     assert [drop["id"] for drop in mixed_data["drops"]] == ["watch"]
     assert mixed_data["claimed_drops"] == 0
     assert mixed_data["total_drops"] == 1
     broadcaster.emit.assert_awaited_once_with("campaign_add", mixed_data)
+
+
+@pytest.mark.asyncio
+async def test_mixed_campaign_claim_counts_only_watch_drops():
+    campaign = _campaign(
+        "mixed",
+        [
+            _drop("sub", "Subscribe", 0),
+            _drop("watch", "Watch", 30),
+        ],
+    )
+    watch_drop = campaign.timed_drops["watch"]
+    watch_drop._claim = AsyncMock(return_value=True)
+
+    assert campaign.total_drops == 1
+    assert campaign.claimed_drops == 0
+    assert campaign.remaining_drops == 1
+
+    await watch_drop.claim()
+
+    assert campaign.claimed_drops == 1
+    assert campaign.remaining_drops == 0
+    claim_message = campaign._twitch.print.call_args.args[0]
+    assert "(1/1)" in claim_message
 
 
 def test_wanted_queue_hides_subscription_drops_and_sub_only_campaigns():

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -348,7 +348,7 @@ function clearWatchingChannel() {
 function channelMatchesGameFilter(channel, gamesToWatchSet) {
     return channel.watching ||
         gamesToWatchSet.size === 0 ||
-        Boolean(channel.game && gamesToWatchSet.has(channel.game));
+        Boolean(channel.game && gamesToWatchSet.has(channel.game.toLowerCase()));
 }
 
 function renderChannels() {
@@ -367,7 +367,7 @@ function renderChannels() {
 
     // Get the games to watch list from settings
     const gamesToWatch = state.settings.games_to_watch || [];
-    const gamesToWatchSet = new Set(gamesToWatch);
+    const gamesToWatchSet = new Set(gamesToWatch.map(g => g.toLowerCase()));
 
     // The active channel remains visible while a settings update changes the
     // game filter; all other channels must match the configured watch list.


### PR DESCRIPTION
## Summary

Follow-up to #84 addressing the post-merge review findings:

- make channel game filtering case-insensitive and cover `Rust` versus `rust`
- retain the legacy `show_not_linked` POST echo with an explicit 1.3.x removal note
- document frontend asset cache versioning and the required release-time version bump
- share the JavaScript function extraction helper across frontend tests
- consolidate Inventory campaign progress computation
- make campaign totals, progress, timing, and claim messages count watch-earnable drops consistently
- correct the Hungarian `about_text` grammar

Locale-wide schema convergence is tracked separately in #85.

## Validation

- `python -W error::RuntimeWarning -m pytest tests/ -q` — 55 passed
- Ruff and Mypy
- Node syntax check and Actionlint
- all language JSON files
- `uv lock --check` and `git diff --check`
- release-script contract tests
- AMD64 Docker build

## Release note

This changes `web/static/app.js`. The release workflow must bump the application version before deployment so `__APP_VERSION__` produces a new asset cache key.