### PR TITLE
Fix Games-to-Watch mining, Available Games, and channel/inventory UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,10 @@ lang/                # Translation JSON files (20 languages)
 
 **src/config/settings.py** - Application settings:
 
-- Games to watch list (auto-populated from available campaigns if empty)
+- Games to watch list (empty means mine nothing; order is mining priority)
+- Games on the Games to Watch list are mined even when Twitch reports NOT LINKED
 - Games can also be added manually from the web settings search box
+- Available Games is populated from discovered campaigns and returned with settings
 - Connection quality multiplier
 - Language selection
 - Proxy support (including verification)
@@ -162,12 +164,15 @@ lang/                # Translation JSON files (20 languages)
 - Drop-name ignore list (`drop_name_blacklist`), empty by default. Entries are literal,
   case-insensitive substrings entered one per line; whitespace and blanks are removed and
   duplicates are casefolded while preserving the first spelling/order.
-- Inventory filters (Status, Benefit Type, Game Search); Active/Upcoming/Expired use
-  OR semantics, Not Linked narrows the result, and Finished opts claimed campaigns in.
-  Zero-minute subscription rewards are omitted from Inventory and Wanted Drops Queue;
-  individually expired and non-mineable rewards are omitted from the queue without hiding
-  upcoming or sequential rewards; successful claims refresh the queue immediately; the
-  actively watched channel remains visible while game settings are changing
+- Inventory filters (Status, Benefit Type, Game Search, Games to Watch only);
+  Active/Upcoming/Expired use OR semantics, Not Linked narrows the result, and Finished
+  opts claimed campaigns in. EXPIRED campaigns are fetched for history. Zero-minute
+  subscription rewards are omitted from Inventory and Wanted Drops Queue; individually
+  expired and non-mineable rewards are omitted from the queue without hiding upcoming or
+  sequential rewards; successful claims refresh the queue immediately; channel groups can
+  be collapsed by game header; priority games without live channels still appear in the
+  Channels panel; the actively watched channel remains visible while game settings are
+  changing
 - Consecutive identical no-active-campaign console prompts are collapsed until another
   console message appears
 
@@ -357,9 +362,11 @@ source env/bin/activate && python -m pytest tests/
 The suite covers settings and proxy behavior, inventory-filter behavior, API filtering,
 GraphQL watch events, batched channel discovery, full-locale translation schema and
 placeholder consistency, frontend DOM safety, case-insensitive channel filtering,
-watch-drop count and expiry semantics, immediate claim refresh behavior, consecutive
-no-campaign console collapsing, and contributor README automation. Frontend behavior tests
-share their JavaScript extraction helper and use Node.js;
+Games-to-Watch priority mining (including NOT LINKED override), Available Games
+population, channel group collapse placeholders, watch-drop count and expiry semantics,
+immediate claim refresh behavior, consecutive no-campaign console collapsing, and
+contributor README automation. Frontend behavior tests share their JavaScript extraction
+helper and use Node.js;
 the validation workflow provisions Node 24 before running pytest. It also runs the release
 script contract tests under `.github/scripts/test/`. Ignore-list coverage includes
 normalization and settings persistence, dependency pruning, the combined expiry/ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,17 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
 including README, contributor and release automation, inventory/watch-drop filtering,
-case-insensitive channel visibility, watch-drop count and expiry semantics, immediate claim
-refresh behavior, frontend asset versioning, full-locale translation schema and placeholder
-parity, synchronized Docker action runtime pins, and consecutive no-active-campaign console
-collapsing, and dependency-aware drop-name ignore rules with truthful ignored/skipped state.
-The Settings **Clear All Cache** action uses `POST /api/cache/clear` to discard local
-campaign, channel, and other derived miner state while preserving OAuth login and settings,
-then reloads from Twitch. It is diagnostic recovery, not a Twitch metadata correction.
+Games-to-Watch priority mining (including NOT LINKED override), Available Games
+population, collapsible channel groups with priority placeholders, case-insensitive
+channel visibility, watch-drop count and expiry semantics, immediate claim refresh
+behavior, frontend asset versioning, full-locale translation schema and placeholder
+parity, synchronized Docker action runtime pins, consecutive no-active-campaign console
+collapsing, and dependency-aware drop-name ignore rules with truthful ignored/skipped
+state. The Settings **Clear All Cache** action uses `POST /api/cache/clear` to discard
+local campaign, channel, and other derived miner state while preserving OAuth login and
+settings, then reloads from Twitch. It is diagnostic recovery, not a Twitch metadata
+correction.
+
+## CLAUDE.md Specific Instructions
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in
+this repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,9 +1,16 @@
 See AGENTS.md for shared repository instructions and current validation coverage,
 including README, contributor and release automation, inventory/watch-drop filtering,
-case-insensitive channel visibility, watch-drop count and expiry semantics, immediate claim
-refresh behavior, frontend asset versioning, full-locale translation schema and placeholder
-parity, synchronized Docker action runtime pins, and consecutive no-active-campaign console
-collapsing, and dependency-aware drop-name ignore rules with truthful ignored/skipped state.
-The Settings **Clear All Cache** action uses `POST /api/cache/clear` to discard local
-campaign, channel, and other derived miner state while preserving OAuth login and settings,
-then reloads from Twitch. It is diagnostic recovery, not a Twitch metadata correction.
+Games-to-Watch priority mining (including NOT LINKED override), Available Games
+population, collapsible channel groups with priority placeholders, case-insensitive
+channel visibility, watch-drop count and expiry semantics, immediate claim refresh
+behavior, frontend asset versioning, full-locale translation schema and placeholder
+parity, synchronized Docker action runtime pins, consecutive no-active-campaign console
+collapsing, and dependency-aware drop-name ignore rules with truthful ignored/skipped
+state. The Settings **Clear All Cache** action uses `POST /api/cache/clear` to discard
+local campaign, channel, and other derived miner state while preserving OAuth login and
+settings, then reloads from Twitch. It is diagnostic recovery, not a Twitch metadata
+correction.
+
+## GEMINI.md Specific Instructions
+
+This file provides guidance to Gemini when working with code in this repository.

--- a/README.md
+++ b/README.md
@@ -70,20 +70,27 @@ Then open <http://localhost:8080>.
 
 1. Log in with your Twitch account through the OAuth device flow.
 2. Wait for the miner to discover available campaigns.
-3. Choose the games you want to prioritize. You can also search for a game, select
-   **Add Game**, and then select **Reload**.
+3. Choose the games you want to prioritize in **Games to Watch**. Order matters
+   (top = highest priority). You can also search for a game, select **Add Game**, and
+   then select **Reload**. Games on this list are mined even when Twitch reports the
+   campaign as **NOT LINKED**.
 4. Leave the miner running while it selects eligible channels and tracks drop progress.
 
 Inventory filters combine **Active**, **Upcoming**, and **Expired** as alternatives.
 **Not Linked** narrows that status result, while fully claimed campaigns stay hidden
-until **Finished** is selected. Zero-minute subscription rewards are omitted from the
-Inventory and Wanted Drops Queue because they cannot be earned by watching. Individually
-expired and non-mineable rewards are also omitted from the queue, while upcoming and
-sequential rewards remain visible; successful claims refresh the queue immediately. The
-channel list matches game names case-insensitively and keeps the actively watched channel
-visible while game settings are changing. Campaign totals and claim messages count only
-rewards that can be earned by watching. Consecutive identical no-active-campaign console
-prompts are collapsed until another console message appears.
+until **Finished** is selected. Optional **Games to Watch only** limits Inventory to
+your priority list. Inventory also loads **EXPIRED** campaigns so you can discover
+historical games to add back to the priority list. Zero-minute subscription rewards are
+omitted from the Inventory and Wanted Drops Queue because they cannot be earned by
+watching. Individually expired and non-mineable rewards are also omitted from the queue,
+while upcoming and sequential rewards remain visible; successful claims refresh the queue
+immediately. The channel list matches game names case-insensitively, keeps every Games to
+Watch entry visible (including games with no live drop channels), supports collapsing
+channel groups by game header, and keeps the actively watched channel visible while game
+settings are changing. Campaign totals and claim messages count only rewards that can be
+earned by watching. Consecutive identical no-active-campaign console prompts are collapsed
+until another console message appears. Settings exposes the full **Available Games** list
+from discovered campaigns (including ones already selected elsewhere).
 
 **Ignored Drop Keywords** in Settings is empty by default. Enter one literal substring per
 line; surrounding whitespace and blank lines are removed, and duplicates are collapsed

--- a/lang/Dansk.json
+++ b/lang/Dansk.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Ingen kanaler sporet endnu...",
             "no_channels_for_games": "Ingen kanaler fundet for valgte spil...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "kanal",
             "channel_count_plural": "kanaler",
             "viewers": "seere"
@@ -121,6 +123,7 @@
                 "upcoming": "Kommende",
                 "expired": "Udløbet",
                 "finished": "Afsluttet",
+                "games_to_watch_only": "Kun Games to Watch",
                 "item": "Genstand",
                 "badge": "Badge",
                 "emote": "Emote",

--- a/lang/Deutsch.json
+++ b/lang/Deutsch.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Noch keine Kanäle verfolgt...",
             "no_channels_for_games": "Keine Kanäle für ausgewählte Spiele gefunden...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "Kanal",
             "channel_count_plural": "Kanäle",
             "viewers": "Zuschauer"
@@ -121,6 +123,7 @@
                 "upcoming": "Kommend",
                 "expired": "Abgelaufen",
                 "finished": "Beendet",
+                "games_to_watch_only": "Nur Games to Watch",
                 "item": "Gegenstand",
                 "badge": "Abzeichen",
                 "emote": "Emote",

--- a/lang/English.json
+++ b/lang/English.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "No channels tracked yet...",
             "no_channels_for_games": "No channels found for selected games...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "channel",
             "channel_count_plural": "channels",
             "viewers": "viewers"
@@ -207,6 +209,7 @@
                 "upcoming": "Upcoming",
                 "expired": "Expired",
                 "finished": "Finished",
+                "games_to_watch_only": "Games to Watch only",
                 "item": "Item",
                 "badge": "Badge",
                 "emote": "Emote",

--- a/lang/Español.json
+++ b/lang/Español.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Aún no se han rastreado canales...",
             "no_channels_for_games": "No se encontraron canales para los juegos seleccionados...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "canal",
             "channel_count_plural": "canales",
             "viewers": "espectadores"
@@ -121,6 +123,7 @@
                 "upcoming": "Próximo",
                 "expired": "Caducado",
                 "finished": "Terminado",
+                "games_to_watch_only": "Solo Games to Watch",
                 "item": "Objeto",
                 "badge": "Insignia",
                 "emote": "Emote",

--- a/lang/Français.json
+++ b/lang/Français.json
@@ -93,6 +93,8 @@
             "offline": "HORS LIGNE ❌",
             "no_channels": "Aucune chaîne suivie pour le moment...",
             "no_channels_for_games": "Aucune chaîne trouvée pour les jeux sélectionnés...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "chaîne",
             "channel_count_plural": "chaînes",
             "viewers": "spectateurs"
@@ -121,6 +123,7 @@
                 "upcoming": "À venir",
                 "expired": "Expiré",
                 "finished": "Terminé",
+                "games_to_watch_only": "Games to Watch uniquement",
                 "item": "Objet",
                 "badge": "Badge",
                 "emote": "Émote",

--- a/lang/Indonesian.json
+++ b/lang/Indonesian.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Belum ada channel yang dilacak...",
             "no_channels_for_games": "Tidak ada channel ditemukan untuk game yang dipilih...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "channel",
             "channel_count_plural": "channel",
             "viewers": "penonton"
@@ -121,6 +123,7 @@
                 "upcoming": "Mendatang",
                 "expired": "Kadaluarsa",
                 "finished": "Selesai",
+                "games_to_watch_only": "Hanya Games to Watch",
                 "item": "Item",
                 "badge": "Lencana",
                 "emote": "Emote",

--- a/lang/Italiano.json
+++ b/lang/Italiano.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Nessun canale tracciato ancora...",
             "no_channels_for_games": "Nessun canale trovato per i giochi selezionati...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "canale",
             "channel_count_plural": "canali",
             "viewers": "spettatori"
@@ -121,6 +123,7 @@
                 "upcoming": "In Arrivo",
                 "expired": "Scaduto",
                 "finished": "Finito",
+                "games_to_watch_only": "Solo Games to Watch",
                 "item": "Oggetto",
                 "badge": "Badge",
                 "emote": "Emote",

--- a/lang/Magyar.json
+++ b/lang/Magyar.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Még nincs követett csatorna...",
             "no_channels_for_games": "Nincs csatorna a kiválasztott játékokhoz...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "csatorna",
             "channel_count_plural": "csatornák",
             "viewers": "néző"
@@ -207,6 +209,7 @@
                 "upcoming": "Hamarosan",
                 "expired": "Lejárt",
                 "finished": "Befejezett",
+                "games_to_watch_only": "Csak Games to Watch",
                 "item": "Tárgy",
                 "badge": "Jelvény",
                 "emote": "Emotikon",

--- a/lang/Nederlandse.json
+++ b/lang/Nederlandse.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Nog geen kanalen gevolgd...",
             "no_channels_for_games": "Geen kanalen gevonden voor geselecteerde games...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "kanaal",
             "channel_count_plural": "kanalen",
             "viewers": "kijkers"
@@ -121,6 +123,7 @@
                 "upcoming": "Aankomend",
                 "expired": "Verlopen",
                 "finished": "Voltooid",
+                "games_to_watch_only": "Alleen Games to Watch",
                 "item": "Item",
                 "badge": "Badge",
                 "emote": "Emote",

--- a/lang/Polski.json
+++ b/lang/Polski.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Nie śledzono jeszcze żadnych kanałów...",
             "no_channels_for_games": "Nie znaleziono kanałów dla wybranych gier...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "kanał",
             "channel_count_plural": "kanały",
             "viewers": "widzowie"
@@ -121,6 +123,7 @@
                 "upcoming": "Nadchodzące",
                 "expired": "Wygasłe",
                 "finished": "Zakończone",
+                "games_to_watch_only": "Tylko Games to Watch",
                 "item": "Przedmiot",
                 "badge": "Odznaka",
                 "emote": "Emotka",

--- a/lang/Português.json
+++ b/lang/Português.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Nenhum canal rastreado ainda...",
             "no_channels_for_games": "Nenhum canal encontrado para os jogos selecionados...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "canal",
             "channel_count_plural": "canais",
             "viewers": "espectadores"
@@ -121,6 +123,7 @@
                 "upcoming": "Próximo",
                 "expired": "Expirado",
                 "finished": "Terminado",
+                "games_to_watch_only": "Somente Games to Watch",
                 "item": "Item",
                 "badge": "Distintivo",
                 "emote": "Emote",

--- a/lang/Română.json
+++ b/lang/Română.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Niciun canal urmărit încă...",
             "no_channels_for_games": "Nu s-au găsit canale pentru jocurile selectate...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "canal",
             "channel_count_plural": "canale",
             "viewers": "spectatori"
@@ -121,6 +123,7 @@
                 "upcoming": "Viitor",
                 "expired": "Expirat",
                 "finished": "Terminat",
+                "games_to_watch_only": "Doar Games to Watch",
                 "item": "Obiect",
                 "badge": "Insignă",
                 "emote": "Emoticon",

--- a/lang/Türkçe.json
+++ b/lang/Türkçe.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Henüz takip edilen kanal yok...",
             "no_channels_for_games": "Seçili oyunlar için kanal bulunamadı...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "kanal",
             "channel_count_plural": "kanal",
             "viewers": "izleyici"
@@ -121,6 +123,7 @@
                 "upcoming": "Yaklaşan",
                 "expired": "Süresi Dolmuş",
                 "finished": "Tamamlanmış",
+                "games_to_watch_only": "Yalnizca Games to Watch",
                 "item": "Eşya",
                 "badge": "Rozet",
                 "emote": "İfade",

--- a/lang/Čeština.json
+++ b/lang/Čeština.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "Zatím nejsou sledovány žádné kanály...",
             "no_channels_for_games": "Pro vybrané hry nebyly nalezeny žádné kanály...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "kanál",
             "channel_count_plural": "kanály",
             "viewers": "diváci"
@@ -121,6 +123,7 @@
                 "upcoming": "Nadcházející",
                 "expired": "Vypršelo",
                 "finished": "Dokončeno",
+                "games_to_watch_only": "Pouze Games to Watch",
                 "item": "Předmět",
                 "badge": "Odznak",
                 "emote": "Emotikon",

--- a/lang/Русский.json
+++ b/lang/Русский.json
@@ -93,6 +93,8 @@
             "offline": "ОФЛАЙН ❌",
             "no_channels": "Пока не отслеживаются каналы...",
             "no_channels_for_games": "Не найдено каналов для выбранных игр...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "канал",
             "channel_count_plural": "каналы",
             "viewers": "зрителей"
@@ -121,6 +123,7 @@
                 "upcoming": "Предстоящие",
                 "expired": "Истекшие",
                 "finished": "Завершенные",
+                "games_to_watch_only": "Только Games to Watch",
                 "item": "Предмет",
                 "badge": "Значок",
                 "emote": "Смайлик",

--- a/lang/Українська.json
+++ b/lang/Українська.json
@@ -93,6 +93,8 @@
             "offline": "ОФЛАЙН ❌",
             "no_channels": "Поки що не відстежуються канали...",
             "no_channels_for_games": "Не знайдено каналів для вибраних ігор...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "канал",
             "channel_count_plural": "канали",
             "viewers": "глядачів"
@@ -121,6 +123,7 @@
                 "upcoming": "Майбутні",
                 "expired": "Завершені",
                 "finished": "Закінчені",
+                "games_to_watch_only": "Лише Games to Watch",
                 "item": "Предмет",
                 "badge": "Значок",
                 "emote": "Смайлик",

--- a/lang/العربية.json
+++ b/lang/العربية.json
@@ -93,6 +93,8 @@
             "offline": "❌ غير نشط",
             "no_channels": "لم يتم تتبع أي قنوات بعد...",
             "no_channels_for_games": "لم يتم العثور على قنوات للألعاب المحددة...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "قناة",
             "channel_count_plural": "قنوات",
             "viewers": "مشاهدين"
@@ -121,6 +123,7 @@
                 "upcoming": "قادم",
                 "expired": "منتهي",
                 "finished": "مكتمل",
+                "games_to_watch_only": "Games to Watch فقط",
                 "item": "عنصر",
                 "badge": "شارة",
                 "emote": "رمز تعبيري",

--- a/lang/日本語.json
+++ b/lang/日本語.json
@@ -93,6 +93,8 @@
             "offline": "オフライン ❌",
             "no_channels": "まだチャンネルが追跡されていません...",
             "no_channels_for_games": "選択したゲームのチャンネルが見つかりません...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "チャンネル",
             "channel_count_plural": "チャンネル",
             "viewers": "視聴者"
@@ -121,6 +123,7 @@
                 "upcoming": "近日開催",
                 "expired": "期限切れ",
                 "finished": "完了",
+                "games_to_watch_only": "Games to Watchのみ",
                 "item": "アイテム",
                 "badge": "バッジ",
                 "emote": "エモート",

--- a/lang/简体中文.json
+++ b/lang/简体中文.json
@@ -93,6 +93,8 @@
             "offline": "OFFLINE ❌",
             "no_channels": "尚未跟踪任何频道...",
             "no_channels_for_games": "所选游戏未找到频道...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "频道",
             "channel_count_plural": "频道",
             "viewers": "观众"
@@ -121,6 +123,7 @@
                 "upcoming": "即将开始",
                 "expired": "已过期",
                 "finished": "已完成",
+                "games_to_watch_only": "仅 Games to Watch",
                 "item": "物品",
                 "badge": "徽章",
                 "emote": "表情",

--- a/lang/繁體中文.json
+++ b/lang/繁體中文.json
@@ -93,6 +93,8 @@
             "offline": "離線 ❌",
             "no_channels": "尚未追蹤任何頻道...",
             "no_channels_for_games": "找不到所選遊戲的頻道...",
+            "no_live_channels": "No live drop channels",
+            "toggle_game": "Click to show/hide channels",
             "channel_count": "頻道",
             "channel_count_plural": "頻道",
             "viewers": "觀眾"
@@ -121,6 +123,7 @@
                 "upcoming": "即將開始",
                 "expired": "已過期",
                 "finished": "已完成",
+                "games_to_watch_only": "僅 Games to Watch",
                 "item": "物品",
                 "badge": "徽章",
                 "emote": "表情",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -18,6 +18,7 @@ class InventoryFilters(TypedDict):
     show_benefit_other: bool
     show_expired: bool
     show_finished: bool
+    show_games_to_watch_only: bool
     show_only_not_linked: bool
     show_upcoming: bool
 
@@ -30,13 +31,14 @@ default_settings = {
     "language": DEFAULT_LANG,
     "inventory_filters": {
         "game_name_search": [],
-        "show_active": False,
+        "show_active": True,
         "show_benefit_badge": True,
         "show_benefit_emote": True,
         "show_benefit_item": True,
         "show_benefit_other": True,
         "show_expired": False,
         "show_finished": False,
+        "show_games_to_watch_only": False,
         "show_only_not_linked": False,
         "show_upcoming": True,
     },

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -336,7 +336,7 @@ class Twitch:
                 # Handle manual mode: check if manual game still has drops
                 if self.is_manual_mode():
                     manual_has_drops = any(
-                        campaign.can_earn_within(next_hour)
+                        campaign.can_earn_within(next_hour, ignore_link=True)
                         and campaign.game == self._manual_target_game
                         for campaign in self.inventory
                     )

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -386,11 +386,29 @@ class Twitch:
                 if self.wanted_games:
                     self.change_state(State.CHANNELS_FETCH)
                 else:
-                    # with no games available, we switch to IDLE after cleanup
-                    self.print(
-                        _.t["status"]["no_campaign"],
-                        collapse_key="status.no_campaign",
+                    # Backend channels are gone; clear stale GUI cards to avoid
+                    # "Channel not found" clicks on leftover priority-list rows.
+                    self.gui.channels.clear()
+                    self.gui.clear_channel_selection()
+                    skip_reasons = self._stream_selector.explain_skipped_games(
+                        self.settings, self.inventory
                     )
+                    if self.settings.games_to_watch and skip_reasons:
+                        reason_text = "; ".join(skip_reasons)
+                        self.print(
+                            f"{_.t['status']['no_campaign']} ({reason_text})",
+                            collapse_key="status.no_campaign",
+                        )
+                        logger.warning(
+                            "No wanted games from games_to_watch=%s: %s",
+                            self.settings.games_to_watch,
+                            reason_text,
+                        )
+                    else:
+                        self.print(
+                            _.t["status"]["no_campaign"],
+                            collapse_key="status.no_campaign",
+                        )
                     self.change_state(State.IDLE)
             elif self._state is State.CHANNELS_FETCH:
                 self.gui.status.update(_.t["gui"]["status"]["gathering"])
@@ -404,7 +422,9 @@ class Twitch:
                 acl_channels: set[Channel] = set()
                 next_hour = datetime.now(timezone.utc) + timedelta(hours=1)
                 for campaign in self.inventory:
-                    if campaign.game in self.wanted_games and campaign.can_earn_within(next_hour):
+                    if campaign.game in self.wanted_games and campaign.can_earn_within(
+                        next_hour, ignore_link=True
+                    ):
                         if campaign.allowed_channels:
                             acl_channels.update(campaign.allowed_channels)
                         else:

--- a/src/i18n/translator.py
+++ b/src/i18n/translator.py
@@ -107,6 +107,8 @@ class GUIChannels(TypedDict):
     offline: str
     no_channels: str
     no_channels_for_games: str
+    no_live_channels: str
+    toggle_game: str
     channel_count: str
     channel_count_plural: str
     viewers: str
@@ -139,6 +141,7 @@ class GUIInvFilters(TypedDict):
     upcoming: str
     expired: str
     finished: str
+    games_to_watch_only: str
     item: str
     badge: str
     emote: str

--- a/src/models/campaign.py
+++ b/src/models/campaign.py
@@ -203,10 +203,14 @@ class DropsCampaign:
             first_drop.display()
 
     def _base_can_earn(
-        self, channel: Channel | None = None, ignore_channel_status: bool = False
+        self,
+        channel: Channel | None = None,
+        ignore_channel_status: bool = False,
+        *,
+        ignore_link: bool = False,
     ) -> bool:
         return (
-            self.eligible  # account is eligible
+            (ignore_link or self.eligible)  # linked, or priority-list override
             and self.active  # campaign is active (and valid)
             and (
                 channel is None
@@ -242,17 +246,24 @@ class DropsCampaign:
             )
         )
 
-    def can_earn(self, channel: Channel | None = None, ignore_channel_status: bool = False) -> bool:
+    def can_earn(
+        self,
+        channel: Channel | None = None,
+        ignore_channel_status: bool = False,
+        *,
+        ignore_link: bool = False,
+    ) -> bool:
         # True if any of the containing drops can be earned
-        return self._base_can_earn(channel, ignore_channel_status) and any(
-            drop._base_can_earn() for drop in self.drops
-        )
+        return self._base_can_earn(
+            channel, ignore_channel_status, ignore_link=ignore_link
+        ) and any(drop._base_can_earn() for drop in self.drops)
 
-    def can_earn_within(self, stamp: datetime) -> bool:
+    def can_earn_within(self, stamp: datetime, *, ignore_link: bool = False) -> bool:
         # Same as can_earn, but doesn't check the channel
-        # and uses a future timestamp to see if we can earn this campaign later
+        # and uses a future timestamp to see if we can earn this campaign later.
+        # ignore_link=True: mine Games-to-Watch entries even when Twitch reports NOT LINKED.
         return (
-            self.eligible
+            (ignore_link or self.eligible)
             and self._valid
             and self.ends_at > datetime.now(timezone.utc)
             and self.starts_at < stamp

--- a/src/models/campaign.py
+++ b/src/models/campaign.py
@@ -190,8 +190,10 @@ class DropsCampaign:
 
     @property
     def first_drop(self) -> TimedDrop | None:
+        # ignore_link=True keeps Campaign Progress in sync with Games-to-Watch mining,
+        # where NOT LINKED campaigns are still progressed.
         drops: list[TimedDrop] = sorted(
-            (drop for drop in self.watch_drops if drop.can_earn()),
+            (drop for drop in self.watch_drops if drop.can_earn(ignore_link=True)),
             key=lambda d: d.remaining_minutes,
         )
         return drops[0] if drops else None

--- a/src/models/drop.py
+++ b/src/models/drop.py
@@ -326,7 +326,9 @@ class TimedDrop(BaseDrop):
         self._twitch.gui.inv.update_drop(self)
 
     def _update_real_minutes(self, delta: int) -> None:
-        if delta == 0 or self.real_current_minutes + delta < 0 or not self.can_earn():
+        if delta == 0 or self.real_current_minutes + delta < 0 or not self.can_earn(
+            ignore_link=True
+        ):
             return
         if self.real_current_minutes + delta < self.required_minutes:
             self.real_current_minutes += delta
@@ -336,7 +338,7 @@ class TimedDrop(BaseDrop):
         self._on_state_changed()
 
     def _bump_minutes(self, channel: Channel | None) -> bool:
-        if self.can_earn(channel):
+        if self.can_earn(channel, ignore_link=True):
             self.extra_current_minutes += 1
             self._on_state_changed()
             if self.extra_current_minutes >= MAX_EXTRA_MINUTES:

--- a/src/models/drop.py
+++ b/src/models/drop.py
@@ -133,9 +133,15 @@ class BaseDrop:
             and self.starts_at < stamp
         )
 
-    def can_earn(self, channel: Channel | None = None, ignore_channel_status: bool = False) -> bool:
+    def can_earn(
+        self,
+        channel: Channel | None = None,
+        ignore_channel_status: bool = False,
+        *,
+        ignore_link: bool = False,
+    ) -> bool:
         return self._base_can_earn() and self.campaign._base_can_earn(
-            channel, ignore_channel_status
+            channel, ignore_channel_status, ignore_link=ignore_link
         )
 
     @property

--- a/src/services/inventory_service.py
+++ b/src/services/inventory_service.py
@@ -148,11 +148,13 @@ class InventoryService:
         # fetch general available campaigns data (campaigns)
         response = await self._twitch.gql_request(GQL_OPERATIONS["Campaigns"])
         available_list: list[JsonType] = response["data"]["currentUser"]["dropCampaigns"] or []
-        applicable_statuses = ("ACTIVE", "UPCOMING")
+        # Include EXPIRED so Inventory can show claimed/history campaigns
+        # (e.g. add Elder Scrolls Online back to Games to Watch).
+        applicable_statuses = ("ACTIVE", "UPCOMING", "EXPIRED")
         available_campaigns: dict[str, JsonType] = {
             c["id"]: c
             for c in available_list
-            if c["status"] in applicable_statuses  # that are currently not expired
+            if c["status"] in applicable_statuses
         }
 
         # fetch detailed data for each campaign, in chunks
@@ -266,7 +268,7 @@ class InventoryService:
 
         campaigns: list[DropsCampaign] = []
         for campaign in self._twitch.inventory:
-            if campaign.can_earn(watching_channel):
+            if campaign.can_earn(watching_channel, ignore_link=True):
                 campaigns.append(campaign)
 
         if campaigns:

--- a/src/services/message_handlers.py
+++ b/src/services/message_handlers.py
@@ -230,7 +230,7 @@ class MessageHandlerService:
                         break
                     await asyncio.sleep(2)
 
-            if campaign.can_earn(watching_channel):
+            if campaign.can_earn(watching_channel, ignore_link=True):
                 self._twitch.restart_watching()
             else:
                 self._twitch.request_inventory_refresh()
@@ -248,7 +248,9 @@ class MessageHandlerService:
 
         logger.log(CALL, f"Drop update from websocket: {drop_text}")
 
-        if drop is not None and drop.can_earn(self._twitch.watching_channel.get_with_default(None)):
+        if drop is not None and drop.can_earn(
+            self._twitch.watching_channel.get_with_default(None), ignore_link=True
+        ):
             # the received payload is for the drop we expected
             drop.update_minutes(message["data"]["current_progress_min"])
 

--- a/src/services/stream_selector.py
+++ b/src/services/stream_selector.py
@@ -11,7 +11,7 @@ class StreamSelector:
     ) -> list[dict]:
         """
         Get the hierarchical tree of wanted items (Games -> Campaigns -> Drops -> Benefits).
-        Ignoring 'can earn within' time constraint.
+        Used for Wanted Drops Queue display; applies mining_benefits filtering.
         """
         wanted_games = []
         games_to_watch = settings.games_to_watch
@@ -32,7 +32,7 @@ class StreamSelector:
                 if game_obj is None:
                     game_obj = campaign.game
 
-                if not campaign.can_earn_within(next_hour):
+                if not campaign.can_earn_within(next_hour, ignore_link=True):
                     continue
 
                 wanted_drops = []
@@ -81,4 +81,55 @@ class StreamSelector:
         ]
 
     def get_wanted_games(self, settings: Settings, campaigns: list[DropsCampaign]) -> list[Game]:
-        return [game["game_obj"] for game in self._get_wanted_game_tree(settings, campaigns)]
+        """
+        Build mining eligibility list in games_to_watch order (DevilXD-aligned).
+
+        A game is wanted if any inventory campaign for that name can progress
+        within the next hour. Games on the priority list are mined even when
+        Twitch reports the campaign as NOT LINKED. Benefit filters do not block
+        mining eligibility.
+        """
+        next_hour = datetime.now(timezone.utc) + timedelta(hours=1)
+        wanted_games: list[Game] = []
+        seen: set[str] = set()
+
+        for game_name in settings.games_to_watch:
+            game_name_lower = game_name.lower()
+            if game_name_lower in seen:
+                continue
+
+            for campaign in campaigns:
+                if campaign.game.name.lower() != game_name_lower:
+                    continue
+                if not campaign.can_earn_within(next_hour, ignore_link=True):
+                    continue
+                wanted_games.append(campaign.game)
+                seen.add(game_name_lower)
+                break
+
+        return wanted_games
+
+    def explain_skipped_games(
+        self, settings: Settings, campaigns: list[DropsCampaign]
+    ) -> list[str]:
+        """
+        Short reasons why games_to_watch entries are not in wanted_games.
+        Used for status/logging when the miner goes idle.
+        """
+        next_hour = datetime.now(timezone.utc) + timedelta(hours=1)
+        wanted_names = {game.name.lower() for game in self.get_wanted_games(settings, campaigns)}
+        reasons: list[str] = []
+
+        for game_name in settings.games_to_watch:
+            if game_name.lower() in wanted_names:
+                continue
+
+            matching = [c for c in campaigns if c.game.name.lower() == game_name.lower()]
+            if not matching:
+                reasons.append(f"{game_name}: no campaign in inventory")
+            elif not any(c.can_earn_within(next_hour, ignore_link=True) for c in matching):
+                reasons.append(f"{game_name}: no earnable drops within 1h")
+            else:
+                reasons.append(f"{game_name}: skipped")
+
+        return reasons

--- a/src/services/watch_service.py
+++ b/src/services/watch_service.py
@@ -78,7 +78,12 @@ class WatchService:
         if channel.game is None or channel.game not in self._twitch.wanted_games:
             return False
 
-        return any(campaign.can_earn(channel) for campaign in self._twitch.inventory)
+        # Priority-list games are mined even when Twitch reports NOT LINKED.
+        return any(
+            campaign.can_earn(channel, ignore_link=True)
+            for campaign in self._twitch.inventory
+            if campaign.game == channel.game
+        )
 
     def should_switch(self, channel: Channel) -> bool:
         """
@@ -223,7 +228,7 @@ class WatchService:
 
                 if drop_data is not None:
                     gql_drop: TimedDrop | None = self._twitch._drops.get(drop_data["dropID"])
-                    if gql_drop is not None and gql_drop.can_earn(channel):
+                    if gql_drop is not None and gql_drop.can_earn(channel, ignore_link=True):
                         gql_drop.update_minutes(drop_data["currentMinutesWatched"])
                         drop_text: str = (
                             f"{gql_drop.name} ({gql_drop.campaign.game}, "

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -145,7 +145,9 @@ async def select_channel(request: ChannelSelectRequest):
         raise HTTPException(status_code=400, detail="Channel is not playing any game")
 
     # Warn if channel has no drops (shouldn't happen if GUI is filtering correctly)
-    if not any(campaign.can_earn(channel) for campaign in twitch_client.inventory):
+    if not any(
+        campaign.can_earn(channel, ignore_link=True) for campaign in twitch_client.inventory
+    ):
         logger.warning(f"User selected channel {channel.name} but it has no available drops")
 
     gui_manager.select_channel(request.channel_id)

--- a/src/web/managers/channels.py
+++ b/src/web/managers/channels.py
@@ -63,6 +63,9 @@ class ChannelListManager:
     def clear(self):
         """Clear all channels from the display list."""
         self._channels.clear()
+        self._watching_id = None
+        if self._gui_manager is not None:
+            self._gui_manager.clear_channel_selection()
         asyncio.create_task(self._broadcaster.emit("channels_clear", {}))
 
     def set_watching(self, channel: Channel):
@@ -133,6 +136,14 @@ class ChannelListManager:
 
         # Atomically replace all channels
         self._channels = new_channels
+
+        # Drop pending selection if the channel was removed in this rebuild
+        if self._gui_manager is not None:
+            selected_id = getattr(self._gui_manager, "_selected_channel_id", None)
+            if selected_id is not None and selected_id not in new_channels:
+                self._gui_manager.clear_channel_selection()
+        if self._watching_id is not None and self._watching_id not in new_channels:
+            self._watching_id = None
 
         # Emit batch update event
         asyncio.create_task(

--- a/src/web/managers/settings.py
+++ b/src/web/managers/settings.py
@@ -56,6 +56,7 @@ class SettingsManager:
             Dictionary containing all user-configurable settings
         """
         settings = vars(self._settings).copy()
+        settings["games_available"] = list(self._available_games)
         # TODO(remove in 1.3.x): Retain this POST-only echo long enough for stale
         # pre-versioned frontends to age out; it never survives a page reload.
         if legacy_show_not_linked is not None:

--- a/tests/test_channel_rendering.py
+++ b/tests/test_channel_rendering.py
@@ -66,3 +66,5 @@ process.stdout.write(JSON.stringify(results));
     render_source = extract_javascript_function(app_source, "renderChannels")
     assert "new Set(gamesToWatch.map(g => g.toLowerCase()))" in render_source
     assert "channelMatchesGameFilter(channel, gamesToWatchSet)" in render_source
+    assert "collapsedChannelGames" in render_source
+    assert "No live drop channels" in render_source or "no_live_channels" in render_source

--- a/tests/test_inventory_filters.py
+++ b/tests/test_inventory_filters.py
@@ -25,12 +25,22 @@ def test_inventory_filter_defaults_hide_finished_without_restricting_link_state(
 
     assert filters["show_finished"] is False
     assert filters["show_only_not_linked"] is False
+    assert filters["show_active"] is True
+    assert filters["show_games_to_watch_only"] is False
     assert "show_not_linked" not in filters
 
     html = INDEX_HTML.read_text(encoding="utf-8")
     input_tag = re.search(r'<input\b[^>]*\bid="filter-not-linked"[^>]*>', html)
     assert input_tag is not None
     assert re.search(r"\bchecked\b", input_tag.group(0)) is None
+
+    active_tag = re.search(r'<input\b[^>]*\bid="filter-active"[^>]*>', html)
+    assert active_tag is not None
+    assert re.search(r"\bchecked\b", active_tag.group(0)) is not None
+
+    priority_tag = re.search(r'<input\b[^>]*\bid="filter-games-to-watch-only"[^>]*>', html)
+    assert priority_tag is not None
+    assert re.search(r"\bchecked\b", priority_tag.group(0)) is None
 
 
 def test_legacy_not_linked_setting_migrates_to_neutral_restriction():
@@ -125,6 +135,8 @@ def test_campaign_filter_behavior_matrix():
         "show_upcoming": False,
         "show_expired": False,
         "show_finished": False,
+        "show_games_to_watch_only": False,
+        "games_to_watch": [],
         "game_name_search": [],
         "show_benefit_item": True,
         "show_benefit_badge": True,
@@ -201,6 +213,29 @@ def test_campaign_filter_behavior_matrix():
         case(
             expected=True,
             campaign_changes={"claimed_drops": 2, "mining_finished": False},
+        ),
+        case(
+            expected=False,
+            filter_changes={
+                "show_games_to_watch_only": True,
+                "games_to_watch": ["Sea of Thieves"],
+            },
+        ),
+        case(
+            expected=True,
+            campaign_changes={"game_name": "Sea of Thieves"},
+            filter_changes={
+                "show_games_to_watch_only": True,
+                "games_to_watch": ["Sea of Thieves"],
+            },
+        ),
+        case(
+            expected=True,
+            campaign_changes={"game_name": "sea of thieves"},
+            filter_changes={
+                "show_games_to_watch_only": True,
+                "games_to_watch": ["Sea of Thieves"],
+            },
         ),
     ]
 

--- a/tests/test_wanted_games_filter.py
+++ b/tests/test_wanted_games_filter.py
@@ -24,6 +24,7 @@ class TestWantedGamesFilter(unittest.TestCase):
         c1 = MagicMock(spec=DropsCampaign)
         c1.game = Game({"id": 1, "name": "Game1"})
         c1.can_earn_within.return_value = True
+        c1.eligible = True
         c1.id = "123"
         c1.name = "Test Campaign"
         c1.campaign_url = "http://test.url"
@@ -37,10 +38,11 @@ class TestWantedGamesFilter(unittest.TestCase):
             DropsCampaign.has_wanted_unclaimed_benefits.__get__(c1, DropsCampaign)
         )
 
-        # Campaign 2: Game2, Can Earn, NO Wanted Benefits -> Should NOT be selected
+        # Campaign 2: Game2, Can Earn, NO Wanted Benefits -> still mineable (DevilXD parity)
         c2 = MagicMock(spec=DropsCampaign)
         c2.game = Game({"id": 2, "name": "Game2"})
         c2.can_earn_within.return_value = True
+        c2.eligible = True
         d2 = MagicMock()
         d2.is_claimed = False
         d2.ends_at = datetime.max.replace(tzinfo=timezone.utc)
@@ -54,6 +56,7 @@ class TestWantedGamesFilter(unittest.TestCase):
         c3 = MagicMock(spec=DropsCampaign)
         c3.game = Game({"id": 3, "name": "Game3"})
         c3.can_earn_within.return_value = True
+        c3.eligible = True
         d3 = MagicMock()
         d3.is_claimed = False
         d3.ends_at = datetime.max.replace(tzinfo=timezone.utc)
@@ -63,10 +66,11 @@ class TestWantedGamesFilter(unittest.TestCase):
             DropsCampaign.has_wanted_unclaimed_benefits.__get__(c3, DropsCampaign)
         )
 
-        # Campaign 4: Game1, Can Earn, Has Claimed Wanted Benefits -> Should NOT be selected
+        # Campaign 4: Game1 duplicate, claimed benefits only -> Game1 already selected via c1
         c4 = MagicMock(spec=DropsCampaign)
         c4.game = Game({"id": 1, "name": "Game1"})
         c4.can_earn_within.return_value = True
+        c4.eligible = True
         c4.id = "123"
         c4.name = "Test Campaign"
         c4.campaign_url = "http://test.url"
@@ -80,10 +84,11 @@ class TestWantedGamesFilter(unittest.TestCase):
             DropsCampaign.has_wanted_unclaimed_benefits.__get__(c4, DropsCampaign)
         )
 
-        # Campaign 5: Game1, Can Not Earn, Has Wanted Benefits -> Should NOT be selected
+        # Campaign 5: Game1, Can Not Earn -> ignored when selecting Game1 (c1 wins)
         c5 = MagicMock(spec=DropsCampaign)
         c5.game = Game({"id": 1, "name": "Game1"})
         c5.can_earn_within.return_value = False
+        c5.eligible = False
         c5.id = "123"
         c5.name = "Test Campaign"
         c5.campaign_url = "http://test.url"
@@ -101,8 +106,85 @@ class TestWantedGamesFilter(unittest.TestCase):
         stream_selector = StreamSelector()
         wanted_games = stream_selector.get_wanted_games(self.settings, inventory)
 
-        self.assertEqual(len(wanted_games), 1)
+        self.assertEqual(len(wanted_games), 2)
         self.assertEqual(wanted_games[0].name, "Game1")
+        self.assertEqual(wanted_games[1].name, "Game2")
+
+    def test_priority_skips_non_earnable_then_selects_next(self):
+        """CoD not earnable + SoT earnable → wanted_games is [Sea of Thieves] only."""
+        self.settings.games_to_watch = [
+            "Call of Duty: Modern Warfare 4",
+            "Sea of Thieves",
+            "ROBLOX",
+        ]
+
+        cod = MagicMock(spec=DropsCampaign)
+        cod.game = Game({"id": 10, "name": "Call of Duty: Modern Warfare 4"})
+        cod.can_earn_within.return_value = False
+        cod.eligible = False
+        cod.drops = []
+
+        sot = MagicMock(spec=DropsCampaign)
+        sot.game = Game({"id": 20, "name": "Sea of Thieves"})
+        sot.can_earn_within.return_value = True
+        sot.eligible = True
+        sot.drops = []
+
+        roblox = MagicMock(spec=DropsCampaign)
+        roblox.game = Game({"id": 30, "name": "ROBLOX"})
+        roblox.can_earn_within.return_value = False
+        roblox.eligible = True
+        roblox.drops = []
+
+        stream_selector = StreamSelector()
+        wanted_games = stream_selector.get_wanted_games(
+            self.settings, [cod, sot, roblox]
+        )
+
+        self.assertEqual([g.name for g in wanted_games], ["Sea of Thieves"])
+
+        reasons = stream_selector.explain_skipped_games(
+            self.settings, [cod, sot, roblox]
+        )
+        self.assertTrue(any("Call of Duty" in r for r in reasons))
+        self.assertTrue(any("ROBLOX" in r for r in reasons))
+        self.assertFalse(any("Sea of Thieves" in r for r in reasons))
+
+    def test_not_linked_priority_game_is_still_wanted(self):
+        """Games to Watch entries mine even when Twitch reports NOT LINKED."""
+        self.settings.games_to_watch = ["Sea of Thieves"]
+
+        sot = MagicMock(spec=DropsCampaign)
+        sot.game = Game({"id": 20, "name": "Sea of Thieves"})
+        sot.linked = False
+        sot.eligible = False
+        sot.can_earn_within.side_effect = (
+            lambda stamp, ignore_link=False: ignore_link
+        )
+        sot.drops = []
+
+        stream_selector = StreamSelector()
+        # Use real can_earn_within behavior via a lightweight stub
+        class StubCampaign:
+            def __init__(self):
+                self.game = Game({"id": 20, "name": "Sea of Thieves"})
+                self.linked = False
+                self.eligible = False
+                self._valid = True
+                self.active = True
+                from datetime import datetime, timedelta, timezone
+                now = datetime.now(timezone.utc)
+                self.starts_at = now - timedelta(hours=1)
+                self.ends_at = now + timedelta(days=1)
+                drop = MagicMock()
+                drop._can_earn_within.return_value = True
+                self.drops = [drop]
+
+            def can_earn_within(self, stamp, *, ignore_link=False):
+                return DropsCampaign.can_earn_within(self, stamp, ignore_link=ignore_link)
+
+        wanted = stream_selector.get_wanted_games(self.settings, [StubCampaign()])
+        self.assertEqual([g.name for g in wanted], ["Sea of Thieves"])
 
 
 if __name__ == "__main__":

--- a/web/index.html
+++ b/web/index.html
@@ -118,7 +118,7 @@
                 <div class="filter-controls">
                     <div class="filter-checkboxes">
                         <label class="filter-checkbox">
-                            <input type="checkbox" id="filter-active" />
+                            <input type="checkbox" id="filter-active" checked />
                             <span>Active</span>
                         </label>
                         <label class="filter-checkbox">
@@ -136,6 +136,10 @@
                         <label class="filter-checkbox">
                             <input type="checkbox" id="filter-finished" />
                             <span>Finished</span>
+                        </label>
+                        <label class="filter-checkbox" title="Show only games from your Games to Watch priority list">
+                            <input type="checkbox" id="filter-games-to-watch-only" />
+                            <span>Games to Watch only</span>
                         </label>
                         <div class="filter-separator"
                             style="width: 1px; height: 24px; background: var(--border-color); margin: 0 10px;">

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -121,6 +121,7 @@ socket.on('initial_state', (data) => {
         data.campaigns.forEach(camp => {
             state.campaigns[camp.id] = camp;
         });
+        rebuildAvailableGamesFromCampaigns();
         renderInventory();
     }
 
@@ -218,7 +219,9 @@ socket.on('inventory_batch_update', (data) => {
     data.campaigns.forEach(camp => {
         state.campaigns[camp.id] = camp;
     });
+    rebuildAvailableGamesFromCampaigns();
     renderInventory();
+    renderChannels();
 });
 
 socket.on('drop_update', (data) => {
@@ -245,10 +248,6 @@ socket.on('login_clear', (data) => {
 
 socket.on('settings_updated', (data) => {
     updateSettingsUI(data);
-});
-
-socket.on('games_available', (data) => {
-    state.availableGames = data.games;
 });
 
 socket.on('theme_change', (data) => {
@@ -351,75 +350,88 @@ function channelMatchesGameFilter(channel, gamesToWatchSet) {
         Boolean(channel.game && gamesToWatchSet.has(channel.game.toLowerCase()));
 }
 
+/** Collapsed game groups in the Channels panel (keyed by lowercase game name). */
+const collapsedChannelGames = new Set();
+
 function renderChannels() {
     const container = document.getElementById('channels-list');
     container.innerHTML = '';
 
     const t = state.translations;
     const channels = Object.values(state.channels);
-    if (channels.length === 0) {
-        const emptyMsg = t.gui?.channels?.no_channels || 'No channels tracked yet...';
-        container.replaceChildren(
-            makeElement('p', { class: 'empty-message' }, emptyMsg),
-        );
-        return;
-    }
-
-    // Get the games to watch list from settings
     const gamesToWatch = state.settings.games_to_watch || [];
     const gamesToWatchSet = new Set(gamesToWatch.map(g => g.toLowerCase()));
 
-    // The active channel remains visible while a settings update changes the
-    // game filter; all other channels must match the configured watch list.
     const filteredChannels = channels.filter(
         channel => channelMatchesGameFilter(channel, gamesToWatchSet)
     );
 
-    if (filteredChannels.length === 0) {
-        const emptyMsg = t.gui?.channels?.no_channels_for_games || 'No channels found for selected games...';
+    // Group live/tracked channels by game
+    const gameGroups = {};
+    filteredChannels.forEach(channel => {
+        const gameName = channel.game || 'No Game';
+        const gameKey = gameName.toLowerCase();
+        const gameIcon = channel.game_icon;
+
+        if (!gameGroups[gameKey]) {
+            gameGroups[gameKey] = {
+                name: gameName,
+                icon: gameIcon,
+                channels: [],
+                fromPriority: gamesToWatchSet.has(gameKey),
+            };
+        }
+        gameGroups[gameKey].channels.push(channel);
+        if (gameIcon && !gameGroups[gameKey].icon) {
+            gameGroups[gameKey].icon = gameIcon;
+        }
+    });
+
+    // Ensure every Games-to-Watch entry appears, even with zero live channels
+    gamesToWatch.forEach(gameName => {
+        const gameKey = gameName.toLowerCase();
+        if (!gameGroups[gameKey]) {
+            const campaign = Object.values(state.campaigns).find(
+                c => (c.game_name || '').toLowerCase() === gameKey
+            );
+            gameGroups[gameKey] = {
+                name: gameName,
+                icon: campaign?.game_box_art_url || null,
+                channels: [],
+                fromPriority: true,
+            };
+        }
+    });
+
+    const groupEntries = Object.entries(gameGroups);
+    if (groupEntries.length === 0) {
+        const emptyMsg = channels.length === 0
+            ? (t.gui?.channels?.no_channels || 'No channels tracked yet...')
+            : (t.gui?.channels?.no_channels_for_games || 'No channels found for selected games...');
         container.replaceChildren(
             makeElement('p', { class: 'empty-message' }, emptyMsg),
         );
         return;
     }
 
-    // Group channels by game
-    const gameGroups = {};
-    filteredChannels.forEach(channel => {
-        const gameName = channel.game || 'No Game';
-        const gameId = channel.game_id || 'no-game';
-        const gameIcon = channel.game_icon;
-
-        if (!gameGroups[gameId]) {
-            gameGroups[gameId] = {
-                name: gameName,
-                icon: gameIcon,
-                channels: []
-            };
-        }
-        gameGroups[gameId].channels.push(channel);
-    });
-
-    // Sort games: prioritize games with watching channels, then by total viewers
-    const sortedGames = Object.entries(gameGroups).sort(([idA, groupA], [idB, groupB]) => {
+    // Sort: watching game first, then games_to_watch order, then by viewers
+    const priorityIndex = new Map(gamesToWatch.map((name, i) => [name.toLowerCase(), i]));
+    const sortedGames = groupEntries.sort(([keyA, groupA], [keyB, groupB]) => {
         const hasWatchingA = groupA.channels.some(ch => ch.watching);
         const hasWatchingB = groupB.channels.some(ch => ch.watching);
-
         if (hasWatchingA !== hasWatchingB) return hasWatchingB ? 1 : -1;
 
-        // Sum total viewers for each game
+        const priA = priorityIndex.has(keyA) ? priorityIndex.get(keyA) : Number.MAX_SAFE_INTEGER;
+        const priB = priorityIndex.has(keyB) ? priorityIndex.get(keyB) : Number.MAX_SAFE_INTEGER;
+        if (priA !== priB) return priA - priB;
+
         const totalViewersA = groupA.channels.reduce((sum, ch) => sum + (ch.viewers || 0), 0);
         const totalViewersB = groupB.channels.reduce((sum, ch) => sum + (ch.viewers || 0), 0);
-
         return totalViewersB - totalViewersA;
     });
 
-    // Render each game group
-    sortedGames.forEach(([gameId, group]) => {
-        // Create game header
-        const gameHeader = document.createElement('div');
-        gameHeader.className = 'game-group-header';
-
+    sortedGames.forEach(([gameKey, group]) => {
+        const isCollapsed = collapsedChannelGames.has(gameKey);
         const channelCount = group.channels.length;
         const totalViewers = group.channels.reduce((sum, ch) => sum + (ch.viewers || 0), 0);
 
@@ -427,25 +439,74 @@ function renderChannels() {
             ? (t.gui?.channels?.channel_count || 'channel')
             : (t.gui?.channels?.channel_count_plural || 'channels');
         const viewersText = t.gui?.channels?.viewers || 'viewers';
+        const statsText = channelCount === 0
+            ? (t.gui?.channels?.no_live_channels || 'No live drop channels')
+            : `${channelCount} ${channelText} • ${totalViewers.toLocaleString()} ${viewersText}`;
 
+        const gameHeader = document.createElement('div');
+        gameHeader.className = 'game-group-header' + (isCollapsed ? ' collapsed' : '');
+        gameHeader.dataset.gameKey = gameKey;
+        gameHeader.title = t.gui?.channels?.toggle_game || 'Click to show/hide channels';
+        gameHeader.setAttribute('role', 'button');
+        gameHeader.tabIndex = 0;
+
+        gameHeader.appendChild(
+            makeElement('span', { class: 'game-group-toggle' }, isCollapsed ? '▸' : '▾')
+        );
         if (group.icon) {
-            gameHeader.appendChild(makeImageElement(group.icon.replace('{width}', '40').replace('{height}', '53'), group.name, 'game-icon'));
+            gameHeader.appendChild(
+                makeImageElement(
+                    group.icon.replace('{width}', '40').replace('{height}', '53'),
+                    group.name,
+                    'game-icon'
+                )
+            );
         }
         gameHeader.appendChild(makeElement('div', { class: 'game-group-info' }, null, el => {
             el.appendChild(makeElement('div', { class: 'game-group-name' }, group.name));
-            el.appendChild(makeElement('div', { class: 'game-group-stats' }, `${channelCount} ${channelText} • ${totalViewers.toLocaleString()} ${viewersText}`));
+            el.appendChild(makeElement('div', { class: 'game-group-stats' }, statsText));
         }));
+
+        const toggleGroup = () => {
+            if (collapsedChannelGames.has(gameKey)) collapsedChannelGames.delete(gameKey);
+            else collapsedChannelGames.add(gameKey);
+            renderChannels();
+        };
+        gameHeader.addEventListener('click', toggleGroup);
+        gameHeader.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleGroup();
+            }
+        });
 
         container.appendChild(gameHeader);
 
-        // Sort channels within game: watching first, then online, then by viewers
+        if (isCollapsed) {
+            return;
+        }
+
+        const channelsWrap = document.createElement('div');
+        channelsWrap.className = 'game-group-channels';
+
+        if (channelCount === 0) {
+            channelsWrap.appendChild(
+                makeElement(
+                    'p',
+                    { class: 'empty-message game-group-empty' },
+                    t.gui?.channels?.no_live_channels || 'No live drop channels for this game right now.'
+                )
+            );
+            container.appendChild(channelsWrap);
+            return;
+        }
+
         group.channels.sort((a, b) => {
             if (a.watching !== b.watching) return b.watching ? 1 : -1;
             if (a.online !== b.online) return b.online ? 1 : -1;
             return (b.viewers || 0) - (a.viewers || 0);
         });
 
-        // Render channels in this game
         group.channels.forEach(channel => {
             const div = document.createElement('div');
             div.className = 'channel-item';
@@ -472,8 +533,9 @@ function renderChannels() {
             div.replaceChildren(nameDiv, infoDiv);
 
             div.onclick = () => selectChannel(channel.id);
-            container.appendChild(div);
+            channelsWrap.appendChild(div);
         });
+        container.appendChild(channelsWrap);
     });
 }
 
@@ -558,6 +620,9 @@ function clearDropProgress() {
 
 function addCampaign(campaignData) {
     state.campaigns[campaignData.id] = campaignData;
+    if (campaignData.game_name) {
+        syncAvailableGames([campaignData.game_name]);
+    }
     renderInventory();
 }
 
@@ -594,6 +659,7 @@ function getInventoryFilters() {
         show_upcoming: document.getElementById('filter-upcoming')?.checked || false,
         show_expired: document.getElementById('filter-expired')?.checked || false,
         show_finished: document.getElementById('filter-finished')?.checked || false,
+        show_games_to_watch_only: document.getElementById('filter-games-to-watch-only')?.checked || false,
         game_name_search: [...selectedInventoryGames],  // Array of selected game names
         // Benefit type filters (default to true if checkbox doesn't exist)
         show_benefit_item: document.getElementById('filter-benefit-item')?.checked !== false,
@@ -613,7 +679,8 @@ function campaignMatchesFilters(campaign, filters) {
     // Finished campaigns are excluded unless the user explicitly includes them.
     if (!filters.show_finished && isFinished) return false;
 
-    // Link state narrows the status result instead of joining its OR group.
+    // Link state narrows the status result instead of joining its OR group
+    // (author contract from PR #79: Not Linked is AND on top of status filters).
     if (filters.show_only_not_linked && campaign.linked) return false;
 
     // Active, upcoming, and expired remain OR-based status filters.
@@ -624,6 +691,15 @@ function campaignMatchesFilters(campaign, filters) {
             (filters.show_upcoming && campaign.upcoming) ||
             (filters.show_expired && campaign.expired);
         if (!statusMatch) return false;
+    }
+
+    // Optional: only campaigns whose game is in the Games to Watch priority list
+    if (filters.show_games_to_watch_only) {
+        const priorityGames = (filters.games_to_watch || []).map(name => String(name).toLowerCase());
+        const gameName = (campaign.game_name || '').toLowerCase();
+        if (!priorityGames.includes(gameName)) {
+            return false;
+        }
     }
 
     // Check game name filter (AND logic with status filters, OR logic among selected games)
@@ -678,6 +754,9 @@ function clearInventoryFilters() {
     document.getElementById('filter-upcoming').checked = false;
     document.getElementById('filter-expired').checked = false;
     document.getElementById('filter-finished').checked = false;
+    if (document.getElementById('filter-games-to-watch-only')) {
+        document.getElementById('filter-games-to-watch-only').checked = false;
+    }
     document.getElementById('inventory-game-search').value = '';
 
     // Reset benefit type filters to checked (show all)
@@ -889,8 +968,11 @@ function renderInventory() {
     const t = state.translations;
     const allCampaigns = Object.values(state.campaigns);
 
-    // Apply filters
-    const filters = getInventoryFilters();
+    // Apply filters (games_to_watch is live settings, not persisted inside inventory_filters)
+    const filters = {
+        ...getInventoryFilters(),
+        games_to_watch: state.settings.games_to_watch || [],
+    };
     const campaigns = allCampaigns.filter(campaign => campaignMatchesFilters(campaign, filters));
 
     if (allCampaigns.length === 0) {
@@ -950,33 +1032,48 @@ function renderInventory() {
                 class: `drop-item${drop.is_claimed ? ' claimed' : ''}${drop.can_claim ? ' active' : ''}${policyClass}`,
                 ...(policyReason ? { title: policyReason } : {}),
             });
-            dropItem.appendChild(
-                makeElement('div', { class: 'drop-item-header' }, '', el =>
-                    el.appendChild(makeElement('div', { class: 'drop-item-info' }, '', el2 =>
-                        el2.appendChild(makeElement('div', {}, '', el3 =>
-                            el3.appendChild(makeElement('strong', {}, drop.name))
-                        ))
-                    ))
-                )
-            );
+
             const benefitsList = makeElement('div', { class: 'benefits-list' });
             if (drop.benefits && drop.benefits.length > 0) {
                 drop.benefits.forEach(benefit => {
                     benefitsList.appendChild(
                         makeElement('div', { class: 'benefit-item' }, '', el => {
-                            el.appendChild(makeImageElement(benefit.image_url, benefit.name, 'benefit-icon'));
+                            if (benefit.image_url) {
+                                el.appendChild(makeImageElement(benefit.image_url, benefit.name, 'benefit-icon'));
+                            }
                             el.appendChild(makeElement('div', { class: 'benefit-info' }, '', el2 => {
-                                el2.appendChild(makeElement('span', { class: 'benefit-name' }, benefit.name));
-                                el2.appendChild(makeElement('span', { class: 'benefit-type' }, `(${benefit.type})`));
+                                el2.appendChild(makeElement('span', { class: 'benefit-name' }, benefit.name || drop.name));
                             }));
                         })
                     );
                 });
+            } else {
+                benefitsList.appendChild(
+                    makeElement('div', { class: 'benefit-item' }, '', el => {
+                        el.appendChild(makeElement('div', { class: 'benefit-info' }, '', el2 => {
+                            el2.appendChild(makeElement('span', { class: 'benefit-name' }, drop.name));
+                        }));
+                    })
+                );
             }
             dropItem.appendChild(benefitsList);
-            dropItem.appendChild(makeElement('div', {}, `${drop.current_minutes} / ${drop.required_minutes} minutes (${Math.round(drop.progress * 100)}%)`));
+
+            const pct = Math.round((drop.progress || 0) * 100);
+            dropItem.appendChild(makeElement('div', { class: 'drop-progress' }, '', el => {
+                el.appendChild(makeElement('div', { class: 'drop-progress-track' }, '', track => {
+                    track.appendChild(makeElement('div', {
+                        class: 'drop-progress-fill',
+                        style: `width: ${pct}%`,
+                    }));
+                }));
+                el.appendChild(makeElement(
+                    'div',
+                    { class: 'drop-progress-text' },
+                    `${drop.current_minutes} / ${drop.required_minutes} min · ${pct}%`
+                ));
+            }));
             if (drop.is_claimed) {
-                dropItem.appendChild(makeElement('div', {}, `✓ ${claimedText}`));
+                dropItem.appendChild(makeElement('div', { class: 'drop-claimed-label' }, `✓ ${claimedText}`));
             } else if (policyStatus) {
                 dropItem.appendChild(makeElement('div', { class: 'drop-policy-status' }, policyStatus));
             }
@@ -988,21 +1085,24 @@ function renderInventory() {
             el.appendChild(makeElement('span', { class: 'external-link-icon' }, '🔗'))
         );
 
-        // Linked/not linked badge
+        // Linked/not linked badge (in-flow, not overlapping the title)
         const linkStatusBadge = campaign.linked
             ? makeElement('span', { class: 'campaign-badge linked', title: 'Account is linked' }, 'LINKED')
             : makeElement('span', { class: 'campaign-badge not-linked', title: 'Click to link your account' }, 'NOT LINKED', el => {
                 el.addEventListener('click', () => window.open(campaign.link_url, '_blank'));
             });
 
-        // Link account button
         const campaignGameDiv = makeElement('div', { class: 'campaign-game' }, '', el => {
             if (campaign.game_box_art_url) {
                 const iconUrl = campaign.game_box_art_url.replace('{width}', '52').replace('{height}', '70');
                 el.appendChild(makeImageElement(iconUrl, campaign.game_name, 'game-icon'));
             }
-            el.appendChild(makeElement('span', { class: 'campaign-game-name' }, campaign.game_name));
-            el.appendChild(linkStatusBadge);
+            el.appendChild(makeElement('div', { class: 'campaign-game-text' }, '', textEl => {
+                textEl.appendChild(makeElement('div', { class: 'campaign-game-title-row' }, '', row => {
+                    row.appendChild(makeElement('span', { class: 'campaign-game-name' }, campaign.game_name));
+                    row.appendChild(linkStatusBadge);
+                }));
+            }));
         });
 
         const campaignHeader = makeElement('div', { class: 'campaign-header' }, '', el => {
@@ -1127,7 +1227,9 @@ function updateSettingsUI(settings) {
 
     // Update available games if provided in settings
     if (settings.games_available) {
-        availableGames = new Set(settings.games_available);
+        syncAvailableGames(settings.games_available);
+    } else {
+        rebuildAvailableGamesFromCampaigns();
     }
 
     // Restore inventory filters from settings
@@ -1137,6 +1239,10 @@ function updateSettingsUI(settings) {
         document.getElementById('filter-upcoming').checked = settings.inventory_filters.show_upcoming || false;
         document.getElementById('filter-expired').checked = settings.inventory_filters.show_expired || false;
         document.getElementById('filter-finished').checked = settings.inventory_filters.show_finished || false;
+        if (document.getElementById('filter-games-to-watch-only')) {
+            document.getElementById('filter-games-to-watch-only').checked =
+                settings.inventory_filters.show_games_to_watch_only || false;
+        }
 
         // Restore selected games array
         selectedInventoryGames = Array.isArray(settings.inventory_filters.game_name_search)
@@ -1207,13 +1313,29 @@ function updateManualModeUI(manualModeInfo) {
 let availableGames = new Set(); // All games from campaigns
 let draggedElement = null;
 
-socket.on('games_available', (data) => {
-    availableGames = new Set(data.games || []);
+function syncAvailableGames(gameNames) {
+    const next = new Set(availableGames);
+    (gameNames || []).forEach(name => {
+        if (name) next.add(name);
+    });
+    availableGames = next;
     renderGamesToWatch();
+}
+
+function rebuildAvailableGamesFromCampaigns() {
+    const fromCampaigns = Object.values(state.campaigns)
+        .map(c => c.game_name)
+        .filter(Boolean);
+    syncAvailableGames(fromCampaigns);
+}
+
+socket.on('games_available', (data) => {
+    syncAvailableGames(data.games || []);
 });
 
 function renderGamesToWatch() {
     const selectedGames = state.settings.games_to_watch || [];
+    const selectedLower = new Set(selectedGames.map(g => g.toLowerCase()));
     const filterText = document.getElementById('games-filter')?.value.toLowerCase() || '';
 
     // Render selected games (sortable)
@@ -1221,9 +1343,9 @@ function renderGamesToWatch() {
 
     // Render available games (checkboxes for unselected games)
     const unselectedGames = Array.from(availableGames)
-        .filter(game => !selectedGames.includes(game))
+        .filter(game => !selectedLower.has(game.toLowerCase()))
         .filter(game => game.toLowerCase().includes(filterText))
-        .sort();
+        .sort((a, b) => a.localeCompare(b));
 
     renderAvailableGames(unselectedGames, filterText);
 }
@@ -1351,8 +1473,9 @@ function handleDragEnd(e) {
     // Re-render to update priority numbers
     renderSelectedGames(newOrder);
 
-    // Re-render channels list to apply updated filter
+    // Re-render channels/inventory to apply updated Games to Watch filters
     renderChannels();
+    renderInventory();
 
     // Save settings
     saveSettings();
@@ -1373,6 +1496,7 @@ function toggleGameWatch(gameName, checked) {
     state.settings.games_to_watch = games;
     renderGamesToWatch();
     renderChannels();
+    renderInventory();
     saveSettings();
 }
 
@@ -1384,6 +1508,7 @@ function removeGameFromWatch(gameName) {
         state.settings.games_to_watch = games;
         renderGamesToWatch();
         renderChannels();
+        renderInventory();
         saveSettings();
     }
 }
@@ -1392,6 +1517,7 @@ function selectAllGames() {
     state.settings.games_to_watch = Array.from(availableGames).sort();
     renderGamesToWatch();
     renderChannels();
+    renderInventory();
     saveSettings();
 }
 
@@ -1399,6 +1525,7 @@ function deselectAllGames() {
     state.settings.games_to_watch = [];
     renderGamesToWatch();
     renderChannels();
+    renderInventory();
     saveSettings();
 }
 
@@ -1430,6 +1557,7 @@ function addGameFromSearch() {
     searchInput.value = '';
     renderGamesToWatch();
     renderChannels();
+    renderInventory();
     saveSettings();
 }
 
@@ -1457,9 +1585,14 @@ async function selectChannel(channelId) {
         });
 
         if (!response.ok) {
-            const errorData = await response.json();
-            console.error('Failed to select channel:', errorData.detail || 'Unknown error');
-            addConsoleLine(`Error selecting channel: ${errorData.detail || 'Unknown error'}`);
+            const errorData = await response.json().catch(() => ({}));
+            const detail = errorData.detail || 'Unknown error';
+            console.error('Failed to select channel:', detail);
+            addConsoleLine(`Error selecting channel: ${detail}`);
+            // Stale GUI card after cleanup/rebuild — drop it so it can't be clicked again
+            if (response.status === 404) {
+                removeChannel(channelId);
+            }
         }
     } catch (error) {
         console.error('Failed to select channel:', error);
@@ -1934,6 +2067,7 @@ function applyTranslations(t) {
         updateLabel('filter-upcoming', f.upcoming);
         updateLabel('filter-expired', f.expired);
         updateLabel('filter-finished', f.finished);
+        updateLabel('filter-games-to-watch-only', f.games_to_watch_only || 'Games to Watch only');
         updateLabel('filter-benefit-item', f.item);
         updateLabel('filter-benefit-badge', f.badge);
         updateLabel('filter-benefit-emote', f.emote);
@@ -2084,6 +2218,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('filter-upcoming').addEventListener('change', onInventoryFilterChange);
     document.getElementById('filter-expired').addEventListener('change', onInventoryFilterChange);
     document.getElementById('filter-finished').addEventListener('change', onInventoryFilterChange);
+    document.getElementById('filter-games-to-watch-only')?.addEventListener('change', onInventoryFilterChange);
     // Benefit type filters
     document.getElementById('filter-benefit-item').addEventListener('change', onInventoryFilterChange);
     document.getElementById('filter-benefit-badge').addEventListener('change', onInventoryFilterChange);

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -403,14 +403,36 @@ header h1 {
     border-radius: 8px;
     color: white;
     font-weight: bold;
-    position: sticky;
-    top: 0;
-    z-index: 10;
+    position: relative;
+    z-index: 1;
     box-shadow: 0 2px 8px rgba(145, 70, 255, 0.3);
+    cursor: pointer;
+    user-select: none;
 }
 
 .game-group-header:first-child {
     margin-top: 0;
+}
+
+.game-group-header.collapsed {
+    opacity: 0.92;
+}
+
+.game-group-toggle {
+    font-size: 14px;
+    width: 1em;
+    flex-shrink: 0;
+    opacity: 0.95;
+}
+
+.game-group-channels {
+    margin-bottom: 4px;
+}
+
+.game-group-empty {
+    margin: 0 0 8px 0;
+    padding: 8px 12px;
+    font-size: 13px;
 }
 
 .game-icon {
@@ -718,7 +740,7 @@ header h1 {
 
 .campaign-game {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 12px;
     font-weight: bold;
     font-size: 16px;
@@ -728,6 +750,24 @@ header h1 {
     width: 52px;
     height: 70px;
     flex-shrink: 0;
+}
+
+.campaign-game-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.campaign-game-title-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.campaign-game-name {
+    min-width: 0;
+    line-height: 1.3;
+    word-break: break-word;
 }
 
 .campaign-name {
@@ -757,15 +797,18 @@ header h1 {
 }
 
 .campaign-badge {
-    position: absolute;
-    right: 15px;
-    padding: 4px 10px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 600;
+    position: static;
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
     cursor: pointer;
     transition: all 0.2s;
-    z-index: 10;
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .campaign-badge.linked {
@@ -971,10 +1014,11 @@ header h1 {
 
 
 .drop-item {
-    padding: 10px;
+    padding: 12px;
     margin-bottom: 8px;
-    background: var(--bg-secondary);
-    border-radius: 4px;
+    background: var(--bg-panel);
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
     border-left: 3px solid var(--border-color);
 }
 
@@ -1025,8 +1069,7 @@ header h1 {
 }
 
 .benefits-list {
-    margin-top: 8px;
-    margin-bottom: 8px;
+    margin: 0 0 10px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -1036,19 +1079,19 @@ header h1 {
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 8px;
-    background: var(--bg-panel);
-    border-radius: 4px;
-    border: 1px solid var(--border-color);
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 0;
 }
 
 .benefit-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 4px;
+    width: 48px;
+    height: 48px;
+    border-radius: 8px;
     object-fit: cover;
-    border: 2px solid var(--border-color);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
     flex-shrink: 0;
 }
 
@@ -1061,15 +1104,46 @@ header h1 {
 }
 
 .benefit-name {
-    font-weight: 500;
+    font-weight: 600;
     font-size: 14px;
     color: var(--text-primary);
+    line-height: 1.3;
 }
 
 .benefit-type {
+    display: none;
+}
+
+.drop-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.drop-progress-track {
+    height: 8px;
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+.drop-progress-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #7c4dff 0%, #00c853 100%);
+}
+
+.drop-progress-text {
     font-size: 12px;
     color: var(--text-secondary);
-    font-style: italic;
+}
+
+.drop-claimed-label {
+    margin-top: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--success-color);
 }
 
 /* Settings */


### PR DESCRIPTION
## Summary

- Mine **Games to Watch** entries even when Twitch reports campaigns as **NOT LINKED** (`ignore_link`), so priority games like Sea of Thieves get live channels instead of idle / "no channels" states
- Preserve DevilXD-style in-list priority: skip non-earnable games and continue to the next Games to Watch entry
- Fix empty **Available Games** by returning `games_available` from settings and rebuilding from discovered campaigns
- Fetch **EXPIRED** campaigns for Inventory history so users can re-add past games to the priority list
- Clear stale channel cards on idle to avoid `Channel not found`, and show every Games to Watch game in Channels (with collapse/expand and empty live-channel placeholders)
- Inventory polish: remove raw `(DIRECT_ENTITLEMENT)` labels, cleaner drop progress UI, LINKED/NOT LINKED badge no longer overlaps the game title
- Keep maintainer inventory-filter contract from #79: Active/Upcoming/Expired remain OR; **Not Linked** remains AND
- Default Inventory **Active** filter to on; optional **Games to Watch only** Inventory filter
- Sync README + AGENTS/CLAUDE/GEMINI docs and locale keys across all 20 languages

## Scope / out of scope

- Out of scope: soft mining mode for games outside the priority list (`priority_list_only` from #76)
- This changes `web/static/app.js` and `web/static/styles.css`; the release workflow must bump the application version and asset cache key before deployment

## Validation

- `python -W error::RuntimeWarning -m pytest tests/ -q` — 100 passed
- `ruff check src tests` — passed
- `mypy src` — passed (56 source files)
- `node --check web/static/app.js` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- all 20 locale JSON files parsed successfully
- Live smoke-tested on Raspberry Pi Docker build against Twitch (priority NOT LINKED games gained live channels; Available Games populated)

Addresses #53